### PR TITLE
Added link to emacs package "flycheck-vale".

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See `vale --help` and [Configuration](https://valelint.github.io/docs/config/) f
 ## Integrations
 
 - Atom&mdash;[TimKam/atomic-vale](https://github.com/TimKam/atomic-vale)
+- Emacs&mdash;[abingham/flycheck-vale](https://github.com/abingham/flycheck-vale)
 - Sublime Text&mdash;[ValeLint/SubVale](https://github.com/ValeLint/SubVale)
 - Vim&mdash;via [ALE](https://github.com/w0rp/ale) (thanks to @[chew-z](https://github.com/chew-z))
 


### PR DESCRIPTION
I added the link in alphabetical order with the rest, but let me know if it should just go at the end instead. 

And thanks, vale is brilliant!