### PR TITLE
docs: Fix a broken link

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -49,7 +49,7 @@ commands and options are discussed below.
     ```
 
     This option takes precedence over any patterns defined in a
-    [configuration file]((https://errata-ai.github.io/vale/config/)).
+    [configuration file](https://errata-ai.github.io/vale/config/).
 
 - `--config`:
 


### PR DESCRIPTION
This link had a double set of parentheses which stopped it working correctly.

I've read the Contributing guidelines and hope that I'm raising this with the appropriate commit comments etc. Please do correct me if I've made any errors.