### PR TITLE
Fix the `brew install` command to point at the correct repository

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -57,6 +57,6 @@ Vale can be installed for local usage. To install the CLI, use one of the follow
 
 - Download an executable from the [releases page](https://github.com/errata-ai/vale/releases)
 - Pulling the [latest Docker container](https://cloud.docker.com/repository/docker/jdkato/vale)
-- On macOS: run `brew install vale`
+- On macOS: run `brew install ValeLint/vale/vale`
 
 **Note:** Depending on the type of file that you lint, you might need to install [extra tools](https://errata-ai.github.io/vale/formats/#formats).


### PR DESCRIPTION
- I tried the existing command, which tries to find formulae in
`Homebrew/homebrew-core`, and got the following error:

```
╭─ issyl0@grus ~
╰─ $ brew install vale
Error: No available formula with the name "vale"
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

- It turns out that there's a [separate Homebrew
  tap](https://github.com/ValeLint/homebrew-vale). It's in a different
  GitHub org, but it installs the most recent version and I assume from
  the name it's related to you!

```
╭─ issyl0@grus ~
╰─ $ brew install ValeLint/vale/vale
==> Tapping valelint/vale
Cloning into '/usr/local/Homebrew/Library/Taps/valelint/homebrew-vale'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Tapped 1 formula (30 files, 24.9KB).

==> Installing vale from valelint/vale
[...]
```