### PR TITLE
Fix doc link for the Docker image

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,7 +69,7 @@ Vale has a commercial desktop application, [Vale Server](https://errata.ai/vale-
 Vale can be installed for local usage. To install the CLI, use one of the following options:
 
 * Download an executable from the [releases page](https://github.com/errata-ai/vale/releases).
-* Pull the [latest Docker container](https://cloud.docker.com/repository/docker/jdkato/vale).
+* Pull the [latest Docker image](https://hub.docker.com/r/jdkato/vale).
 * Use one of the available [package managers](https://repology.org/project/vale/versions):
 
 ![](https://repology.org/badge/vertical-allrepos/vale.svg)


### PR DESCRIPTION
The previous link (cloud.docker.com) required authentication.  The new link (hub.docker.com) does not.

Also fix terminology.  Change "container" to "image".  A Docker container is an instance of a Docker image.  Docker Hub hosts Docker images.  The term "container image" is also valid.