### PR TITLE
style: suggest non-oppressive terminology

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -895,7 +895,7 @@ func (mgr *Manager) loadStyles(styles []string, loaded []string) []string {
 }
 
 func (mgr *Manager) loadVocabRules(config *core.Config) {
-	// Whitelist
+	// Allowlist or Permit
 	if len(config.AcceptedTokens) > 0 {
 		vocab := Substitution{}
 		vocab.Extends = "substitution"
@@ -913,7 +913,7 @@ func (mgr *Manager) loadVocabRules(config *core.Config) {
 		mgr.addSubstitutionCheck("Vale.Terms", vocab)
 	}
 
-	// Blacklist
+	// Blocklist or Block
 	if len(config.RejectedTokens) > 0 {
 		avoid := Existence{}
 		avoid.Extends = "existence"


### PR DESCRIPTION
I'm a new user to Vale and appreciate, for example, your suggestions for inclusive language. As a result, when I saw `whitelist` and `blacklist` when running `vale ls-config, I was surprised. I'm not sure what all you'll need to do from the backend to make this shift, but consider using something like `allowlist/blocklist` or `permit/block` instead.

Here's a good resource: https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.2

Have a great day!