### PR TITLE
Add support for org mode markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Vale is a command-line tool that brings code-like linting to prose. It's cross-platform (Windows, macOS, and Linux), written in Go, and released under the MIT license. Some of its key features are:
 
-* [Usability](https://docs.errata.ai/vale/scoping): Vale supports HTML, Markdown, AsciiDoc, reStructuredText, XML, and
+* [Usability](https://docs.errata.ai/vale/scoping): Vale supports HTML, Markdown, Emacs Org mode, AsciiDoc, reStructuredText, XML, and
   DITA&mdash;allowing it to "just work" on *real-world* content.
 
 * [Extensibility](https://docs.errata.ai/vale/styles): Unlike most writing-related software, Vale's primary purpose isn't

--- a/core/format.go
+++ b/core/format.go
@@ -67,6 +67,7 @@ var FormatByExtension = map[string][]string{
 	`\.(?:js)$`:                                   {".c", "code"},
 	`\.(?:lua)$`:                                  {".lua", "code"},
 	`\.(?:md|mdown|markdown|markdn)$`:             {".md", "markup"},
+	`\.(?:org)$`:                                  {".org", "markup"},
 	`\.(?:php)$`:                                  {".php", "code"},
 	`\.(?:pl|pm|pod)$`:                            {".r", "code"},
 	`\.(?:r|R)$`:                                  {".r", "code"},

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -9,6 +9,7 @@ func TestFormatFromExt(t *testing.T) {
 		".py":    {".py", "code"},
 		".cxx":   {".c", "code"},
 		".mdown": {".md", "markup"},
+		".org":   {".org", "markup"},
 	}
 	m := map[string]string{}
 	for ext, format := range extToFormat {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/montanaflynn/stats v0.6.3 // indirect
 	github.com/neurosnap/sentences v1.0.6 // indirect
+	github.com/niklasfasching/go-org v1.3.2
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/shogo82148/go-shuffle v0.0.0-20180218125048-27e6095f230d // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/montanaflynn/stats v0.6.3 h1:F8446DrvIF5V5smZfZ8K9nrmmix0AFgevPdLruGO
 github.com/montanaflynn/stats v0.6.3/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/neurosnap/sentences v1.0.6 h1:iBVUivNtlwGkYsJblWV8GGVFmXzZzak907Ci8aA0VTE=
 github.com/neurosnap/sentences v1.0.6/go.mod h1:pg1IapvYpWCJJm/Etxeh0+gtMf1rI1STY9S7eUCPbDc=
+github.com/niklasfasching/go-org v1.3.2 h1:ZKTSd+GdJYkoZl1pBXLR/k7DRiRXnmB96TRiHmHdzwI=
+github.com/niklasfasching/go-org v1.3.2/go.mod h1:AsLD6X7djzRIz4/RFZu8vwRL0VGjUvGZCCH1Nz0VdrU=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -196,6 +196,8 @@ func (l *Linter) lintFile(src string) *core.File {
 			}
 		case ".md":
 			l.lintMarkdown(file)
+		case ".org":
+			l.lintOrg(file)
 		case ".rst":
 			cmd := core.Which([]string{"rst2html", "rst2html.py"})
 			runtime := core.Which([]string{"python", "py", "python.exe", "python3", "python3.exe", "py3"})

--- a/lint/markup.go
+++ b/lint/markup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/errata-ai/vale/core"
 	"github.com/gobwas/glob"
 	"github.com/jdkato/regexp"
+	"github.com/niklasfasching/go-org/org"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	grh "github.com/yuin/goldmark/renderer/html"
@@ -383,6 +384,17 @@ func (l Linter) lintMarkdown(f *core.File) {
 	s := l.prep(f.Content, "\n```\n$1\n```\n", "`$1`", ".md")
 	if core.CheckError(goldMd.Convert([]byte(s), &buf), l.CheckManager.Config.Debug) {
 		l.lintHTMLTokens(f, f.Content, buf.Bytes(), 0)
+	}
+}
+
+func (l Linter) lintOrg(f *core.File) {
+	file := filepath.Base(f.Path)
+	doc := org.New().Parse(bytes.NewReader([]byte(f.Content)), file)
+	if core.CheckError(doc.Error, l.CheckManager.Config.Debug) {
+		s, err := doc.Write(org.NewHTMLWriter())
+		if core.CheckError(err, l.CheckManager.Config.Debug) {
+			l.lintHTMLTokens(f, f.Content, []byte(s), 0)
+		}
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,6 +46,9 @@ github.com/mitchellh/mapstructure
 github.com/montanaflynn/stats
 # github.com/neurosnap/sentences v1.0.6
 ## explicit
+# github.com/niklasfasching/go-org v1.3.2
+## explicit
+github.com/niklasfasching/go-org/org
 # github.com/olekukonko/tablewriter v0.0.4
 ## explicit
 github.com/olekukonko/tablewriter


### PR DESCRIPTION
Uses the [go-org](https://github.com/niklasfasching/go-org/org) library and convert to HTML, just like the markdown implementation.

![Screenshot from 2020-09-15 21-50-18](https://user-images.githubusercontent.com/15332/93257794-af3a9680-f79d-11ea-982b-7a4272d875c8.png)
