### PR TITLE
feat: Ignore directories out of the box

### DIFF
--- a/core/util.go
+++ b/core/util.go
@@ -29,6 +29,21 @@ var code = regexp.MustCompile("`?`[^`@\n]+``?")
 // This is used to store patterns as we compute them in `initialPosition`.
 var cache = sync.Map{}
 
+// DefaultIgnoreDirectories is list of directories which will be ignored by vale, out of the box
+var DefaultIgnoreDirectories = []string{
+	"node_modules", ".git",
+}
+
+// ShouldIgnoreDirectory will check if directory should be ignored
+func ShouldIgnoreDirectory(directoryName string) bool {
+	for _, directory := range DefaultIgnoreDirectories {
+		if directory == directoryName {
+			return true
+		}
+	}
+	return false
+}
+
 // Hash computes the MD5 hash of the given string.
 func Hash(text string) string {
 	hasher := md5.New()

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -122,6 +122,11 @@ func (l *Linter) lintFiles(done <-chan core.File, root string) (<-chan lintResul
 		wg := sizedwaitgroup.New(5)
 
 		err := filepath.Walk(root, func(fp string, fi os.FileInfo, err error) error {
+
+			if fi.IsDir() && core.ShouldIgnoreDirectory(fi.Name()) {
+				return filepath.SkipDir
+			}
+
 			if err != nil || fi.IsDir() {
 				return nil
 			} else if l.skip(fp) {


### PR DESCRIPTION
```node_modules``` & ```.git``` are ignored by default. Since walking on these directories is overload, It will great performance improvement for node applications. We can also add ```vendor``` to this list.