### PR TITLE
Allow dashes and slashes in capitalization rule exception items

### DIFF
--- a/check/variables.go
+++ b/check/variables.go
@@ -16,7 +16,7 @@ func isMatch(r *regexp.Regexp, s string) bool {
 }
 
 func makeExceptions(ignore []string) *regexp.Regexp {
-	ignore = append(ignore, `[\p{N}\p{L}*]+[^\s-/]*`)
+	ignore = append(ignore, `[\p{N}\p{L}*]+[^\s]*`)
 	return regexp.MustCompile(`(?:` + strings.Join(ignore, "|") + `)`)
 }
 

--- a/check/variables_test.go
+++ b/check/variables_test.go
@@ -35,6 +35,11 @@ func TestSentence(t *testing.T) {
 			match:      true,
 			exceptions: []string{"Event Store"},
 		},
+		{
+			heading:    "Using errata-ai/vale",
+			match:      true,
+			exceptions: []string{"errata-ai/vale"},
+		},
 	}
 
 	for _, h := range headings {


### PR DESCRIPTION
- First of all, thanks for building Vale!
- In [Homebrew's styles](https://github.com/Homebrew/brew/blob/master/docs/vale-styles/Homebrew/Titles.yml), we have titlecase rule capitalization exceptions for full repo names that appear in our docs: for example, "Homebrew/homebrew-core".
- This regexp was changed in 10f7c3381d04d3f3bd9fe0ff34b6167d94baeb1f to match characters other than `-` and `/` etc, which breaks our exclusions.
- If there's a better way to do this, I'll happily take advice!

Before:

```
$ vale docs/

 docs/Homebrew-homebrew-core-Merge-Checklist.md
 1:3  error  'Homebrew/homebrew-core Merge   Homebrew.Titles
             Checklist' should be in title
             case

 docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
 1:3  error  'Homebrew/linuxbrew-core        Homebrew.Titles
             Maintainer Guide' should be in
             title case

✖ 2 errors, 0 warnings and 0 suggestions in 51 files.
```

After:

```
$ ./vale --config=/usr/local/Homebrew/.vale.ini /usr/local/Homebrew/docs/
✔ 0 errors, 0 warnings and 0 suggestions in 51 files.
```