### PR TITLE
Make LintedTotal available in custom template

### DIFF
--- a/ui/custom.go
+++ b/ui/custom.go
@@ -21,7 +21,8 @@ type ProcessedFile struct {
 
 // Data holds the information exposed to UI templates.
 type Data struct {
-	Files []ProcessedFile
+	Files       []ProcessedFile
+	LintedTotal int
 }
 
 var funcs = sprig.TxtFuncMap()
@@ -91,6 +92,7 @@ func PrintCustomAlerts(linted []*core.File, path string) (bool, error) {
 	}
 
 	return alertCount != 0, t.Execute(os.Stdout, Data{
-		Files: formatted,
+		Files:       formatted,
+		LintedTotal: len(linted),
 	})
 }


### PR DESCRIPTION
:wave: Hi 🙂 This PR makes the linted file count available when using custom templates.

Using the custom template:

```
{{- /* Modify Vale's output https://docs.errata.ai/vale/cli#--output */ -}}

{{- /* Keep track of our various counts */ -}}

{{- $e := 0 -}}
{{- $w := 0 -}}
{{- $s := 0 -}}
{{- $f := 0 -}}

{{- /* Range over the linted files */ -}}

{{- range .Files}}

{{- $f = add1 $f -}}
{{- $path := .Path | underline -}}

{{- /* Range over the file's alerts */ -}}

{{- range .Alerts -}}

{{- $error := "" -}}
{{- if eq .Severity "error" -}}
    {{- $error = .Severity | red -}}
    {{- $e = add1 $e  -}}
{{- else if eq .Severity "warning" -}}
    {{- $error = .Severity | yellow -}}
    {{- $w = add1 $w -}}
{{- else -}}
    {{- $error = .Severity | blue -}}
    {{- $s = add1 $s -}}
{{- end}}

{{- /* Variables setup */ -}}

{{- $path = $path -}}
{{- $loc := printf "Line %d, position %d" .Line (index .Span 0) -}}
{{- $check := printf "%s" .Check -}}
{{- $message := printf "%s" .Message -}}
{{- $link := printf "%s" .Link -}}

{{- /* Output */ -}}

{{ $path }}:
 {{ $loc }} (rule {{ $check }})
 {{ $error }}: {{ $message }}
 More information: {{ $link }}

{{end -}}
{{end -}}

{{- $e}} {{"errors" | red}}, {{$w}} {{"warnings" | yellow}} and {{$s}} {{"suggestions" | blue}} in {{$f}} of {{.LintedTotal}} {{.LintedTotal | plural "file" "files"}}.
```

And running, produces:

```sh
$ vale --config .vale.ini --minAlertLevel error --output .vale/vale.tmpl **/*.md
--snip--
3 errors, 0 warnings and 0 suggestions in 2 of 18 files.
```