### PR TITLE
Ignore link text when the text is equals to href

### DIFF
--- a/features/lint.feature
+++ b/features/lint.feature
@@ -51,6 +51,7 @@ Feature: Lint
       """
       test2.adoc:3:17:Test.Rule2:Consider using 'AsciiDoc' instead of 'Asciidoc'
       test2.adoc:11:7:Test.Rule2:Consider using 'AsciiDoc' instead of 'asciidoc'
+      test2.adoc:20:49:Test.Rule2:Consider using 'AsciiDoc' instead of 'Asciidoc'
       """
     And the exit status should be 1
 

--- a/fixtures/formats/adoc/test2.adoc
+++ b/fixtures/formats/adoc/test2.adoc
@@ -9,3 +9,7 @@ some asciidoc
 
 Asciidoctor is a fast, open source text processor and publishing toolchain
 for converting asciidoc content to HTML5, DocBook, PDF, and other formats.
+
+== Learn more
+
+* xref:about-asciidoc.adoc[]

--- a/fixtures/formats/adoc/test2.adoc
+++ b/fixtures/formats/adoc/test2.adoc
@@ -12,6 +12,9 @@ for converting asciidoc content to HTML5, DocBook, PDF, and other formats.
 
 == Learn more
 
+// ignore bare links
 * xref:about-asciidoc.adoc[]
 * https://docs.asciidoc.org
 * https://docs.org#asciidoc
+// Vale must lint text link: Asciidoc -> AsciiDoc
+* https://docs.asciidoctor.org/asciidoc/latest/[Asciidoc Language Documentation]

--- a/fixtures/formats/adoc/test2.adoc
+++ b/fixtures/formats/adoc/test2.adoc
@@ -13,3 +13,5 @@ for converting asciidoc content to HTML5, DocBook, PDF, and other formats.
 == Learn more
 
 * xref:about-asciidoc.adoc[]
+* https://docs.asciidoc.org
+* https://docs.org#asciidoc

--- a/lint/walk.go
+++ b/lint/walk.go
@@ -14,6 +14,7 @@ type walker struct {
 	section   string
 	context   string
 	activeTag string
+	activeHref string
 
 	idx int
 	z   *html.Tokenizer
@@ -53,9 +54,13 @@ func (w *walker) append(text string) {
 	}
 }
 
-func (w *walker) addTag(tag string) {
+func (w *walker) addTag(tok html.Token) {
+	tag := html.UnescapeString(strings.TrimSpace(tok.Data))
 	w.tagHistory = append(w.tagHistory, tag)
 	w.activeTag = tag
+	if tag == "a" {
+		w.activeHref = getAttribute(tok, "href")
+	}
 }
 
 func (w *walker) block(text, scope string) core.Block {


### PR DESCRIPTION
Ignore the text of a link when the value is equals to the href attribute. As a result, the linter will ignore the following occurrences:

```html
<a href="https://www.google.fr">https://www.google.fr</a>
```

```html
<a href="file.html">file.html</a>
```

In the above case, I believe that Vale should not lint the text since the value is actually an URL. Vale will still lint the text when the value is not equals to the href. For instance:

```html
<a href="https://www.google.fr">www.google.fr</a>
```

```html
<a href="foo.html">bar.html</a>
```

Using [`url.Parse`](https://golang.org/pkg/net/url/#Parse) to check that the text is an URL could produce false positive.

I think this change is reasonable since we know that the text of the link is actually an URL (since the value is equals to the `href` attribute). As mentioned in #297, it should be possible to define a `BlockIgnores` to explicitly ignore bare links but I think it should be built-in.

ref #297 