### PR TITLE
feat: Support Severity in line output

### DIFF
--- a/internal/cli/line.go
+++ b/internal/cli/line.go
@@ -33,8 +33,8 @@ func PrintLineAlerts(linted []*core.File, relative bool) bool {
 			if a.Severity == "error" {
 				alertCount++
 			}
-			fmt.Print(fmt.Sprintf("%s:%d:%d:%s:%s\n",
-				base, a.Line, a.Span[0], a.Check, a.Message))
+			fmt.Print(fmt.Sprintf("%s:%d:%d:%s:%s:%s\n",
+				base, a.Line, a.Span[0], a.Severity, a.Check, a.Message))
 		}
 	}
 	return alertCount != 0


### PR DESCRIPTION
This adds severity to the line output. 

```
.../hybrids.md:25:270:warning:Google.Will:Avoid using 'will'.
.../hybrids.md:25:291:error:Vale.Spelling:Did you really mean 'squrriels'?
```

Previous

```
.../hybrids.md:25:270:Google.Will:Avoid using 'will'.
.../hybrids.md:25:291:Vale.Spelling:Did you really mean 'squrriels'?
```

This **will break** support for previous matches so maybe a better approach to adding this to the line output. Maybe adding another version of the line output for backwards compat. 

```
vale --output=line-severity
```