### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GEM
       ffi (~> 1.9)
       rspec-expectations (>= 2.99)
       thor (>= 0.19, < 2.0)
-    builder (3.2.3)
+    builder (3.2.4)
     childprocess (3.0.0)
-    contracts (0.16.0)
+    contracts (0.16.1)
     cucumber (2.3.3)
       builder (>= 2.1.2)
       cucumber-core (~> 1.4.0)
@@ -22,18 +22,18 @@ GEM
     cucumber-core (1.4.0)
       gherkin (~> 3.2.0)
     cucumber-wire (0.0.1)
-    diff-lcs (1.3)
-    ffi (1.12.2)
+    diff-lcs (1.4.4)
+    ffi (1.15.4)
     gherkin (3.2.0)
-    multi_json (1.12.1)
+    multi_json (1.15.0)
     multi_test (0.1.2)
     os (0.9.6)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
-    specific_install (0.3.3)
-    thor (1.0.1)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.3)
+    specific_install (0.3.7)
+    thor (1.1.0)
 
 PLATFORMS
   ruby
@@ -45,4 +45,4 @@ DEPENDENCIES
   specific_install (~> 0.3.3)
 
 BUNDLED WITH
-   2.1.2
+   2.2.31

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: "{build}"
-os: Windows Server 2012 R2
+image: Visual Studio 2022
 clone_folder: c:\GOPATH\src\github.com\errata-ai\vale
 environment:
   GOPATH: c:\GOPATH

--- a/cmd/vale/main.go
+++ b/cmd/vale/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/errata-ai/vale/v2/internal/cli"
@@ -72,7 +72,7 @@ func doLint(args []string, l *lint.Linter, glob string) ([]*core.File, error) {
 		// Case 3:
 		//
 		// $ cat file.md | vale
-		stdin, err := ioutil.ReadAll(os.Stdin)
+		stdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return linted, core.NewE100("doLint", err)
 		}

--- a/internal/check/manager.go
+++ b/internal/check/manager.go
@@ -3,7 +3,7 @@ package check
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -78,7 +78,7 @@ func (mgr *Manager) AddRule(name string, rule Rule) error {
 
 // AddRuleFromFile adds the given rule to the manager.
 func (mgr *Manager) AddRuleFromFile(name, path string) error {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return core.NewE100("ReadFile", err)
 	}
@@ -129,7 +129,7 @@ func (mgr *Manager) addStyle(path string) error {
 
 func (mgr *Manager) addRuleFromSource(name, path string) error {
 	if strings.HasSuffix(name, ".yml") {
-		f, err := ioutil.ReadFile(path)
+		f, err := os.ReadFile(path)
 		if err != nil {
 			return core.NewE201FromPosition(err.Error(), path, 1)
 		}

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -109,7 +108,7 @@ func fetch(src, dst string) error {
 	}
 
 	// Create a temp file to represent the archive locally:
-	tmpfile, err := ioutil.TempFile("", "temp.*.zip")
+	tmpfile, err := os.CreateTemp("", "temp.*.zip")
 	if err != nil {
 		return err
 	}
@@ -321,7 +320,7 @@ func edit(alert core.Alert) ([]string, error) {
 func ListDir(path, entry string) ([]string, error) {
 	var styles []string
 
-	files, err := ioutil.ReadDir(filepath.Join(path, entry))
+	files, err := os.ReadDir(filepath.Join(path, entry))
 	if err != nil {
 		return styles, err
 	}
@@ -344,7 +343,7 @@ func AddProject(path, name string) error {
 	}
 
 	for _, f := range []string{"accept.txt", "reject.txt"} {
-		ferr = ioutil.WriteFile(filepath.Join(root, f), []byte{}, 0644)
+		ferr = os.WriteFile(filepath.Join(root, f), []byte{}, 0644)
 	}
 
 	return ferr
@@ -366,7 +365,7 @@ func EditProject(args []string) error {
 func UpdateVocab(args []string) error {
 	parts := strings.Split(args[1], ".")
 	dest := filepath.Join(args[0], "Vocab", parts[0], parts[1]+".txt")
-	return ioutil.WriteFile(dest, []byte(args[2]), 0644)
+	return os.WriteFile(dest, []byte(args[2]), 0644)
 }
 
 // GetVocab extracts a vocab file for a project.
@@ -418,7 +417,7 @@ func GetLibrary(path string) ([]Style, error) {
 			name := filepath.Base(filepath.Dir(osPathname))
 			meta := Meta{}
 
-			f, _ := ioutil.ReadFile(osPathname)
+			f, _ := os.ReadFile(osPathname)
 			if err := json.Unmarshal(f, &meta); err != nil {
 				return err
 			}

--- a/internal/cli/custom.go
+++ b/internal/cli/custom.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -25,7 +24,7 @@ type Data struct {
 func PrintCustomAlerts(linted []*core.File, path string) (bool, error) {
 	var alertCount int
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return false, core.NewE100("template", err)
 	}

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -34,7 +34,7 @@ func readJSON(url string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func printJSON(t interface{}) error {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -162,7 +162,7 @@ func NewFile(src string, config *Config) (*File, error) {
 	var fbytes []byte
 
 	if FileExists(src) {
-		fbytes, _ = ioutil.ReadFile(src)
+		fbytes, _ = os.ReadFile(src)
 		if config.Flags.InExt != ".txt" {
 			ext, format = FormatFromExt(config.Flags.InExt, config.Formats)
 		} else {

--- a/internal/core/error.go
+++ b/internal/core/error.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -114,7 +114,7 @@ func NewE100(context string, err error) error {
 //
 // <path>:<line>:<start>:<end>
 func NewE201(msg, value, path string, finder errorCondition) error {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return NewE100("NewE201", errors.New(msg))
 	}

--- a/internal/lint/adoc.go
+++ b/internal/lint/adoc.go
@@ -3,7 +3,6 @@ package lint
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -145,7 +144,7 @@ func (l *Linter) startAdocServer(exe string) error {
 		return errors.New("GEM_HOME parsing failed")
 	}
 
-	tmpfile, _ := ioutil.TempFile("", "server.*.rb")
+	tmpfile, _ := os.CreateTemp("", "server.*.rb")
 	if _, err := tmpfile.WriteString(adocServer); err != nil {
 		return err
 	}
@@ -198,7 +197,7 @@ func findGems(exe string) (string, error) {
 		}
 	}
 
-	bin, err := ioutil.ReadFile(exe)
+	bin, err := os.ReadFile(exe)
 	if err != nil {
 		return home, err
 	}

--- a/internal/lint/dita.go
+++ b/internal/lint/dita.go
@@ -3,7 +3,6 @@ package lint
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,7 +21,7 @@ func (l Linter) lintDITA(file *core.File) error {
 		return core.NewE100("lintDITA", errors.New("dita not found"))
 	}
 
-	tempDir, err := ioutil.TempDir("", "dita-")
+	tempDir, err := os.MkdirTemp("", "dita-")
 	defer os.RemoveAll(tempDir)
 
 	if err != nil {
@@ -62,7 +61,7 @@ func (l Linter) lintDITA(file *core.File) error {
 		FollowSymbolicLinks: true,
 	})
 
-	data, err := ioutil.ReadFile(htmlFile)
+	data, err := os.ReadFile(htmlFile)
 	if err != nil {
 		return core.NewE100(htmlFile, err)
 	}

--- a/internal/lint/html.go
+++ b/internal/lint/html.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -92,7 +93,7 @@ func (l *Linter) post(f *core.File, text, url string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == 200 {
 		return string(body), nil
 	}
@@ -101,7 +102,7 @@ func (l *Linter) post(f *core.File, text, url string) (string, error) {
 }
 
 func (l *Linter) lintTxtToHTML(f *core.File) error {
-	html, err := ioutil.ReadFile(l.Manager.Config.Flags.Built)
+	html, err := os.ReadFile(l.Manager.Config.Flags.Built)
 	if err != nil {
 		return core.NewE100(f.Path, err)
 	}

--- a/internal/lint/rst.go
+++ b/internal/lint/rst.go
@@ -3,7 +3,7 @@ package lint
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -131,7 +131,7 @@ func (l *Linter) lintSphinx(f *core.File) error {
 	built := strings.Replace(file, filepath.Ext(file), ".html", 1)
 	built = filepath.Join(l.Manager.Config.SphinxBuild, "html", built)
 
-	html, err := ioutil.ReadFile(built)
+	html, err := os.ReadFile(built)
 	if err != nil {
 		return core.NewE100(f.Path, err)
 	}
@@ -229,7 +229,7 @@ func (l *Linter) startRstServer(lib, exe string) error {
 		return errors.New("shebang parsing failed")
 	}
 
-	tmpfile, _ := ioutil.TempFile("", "server.*.py")
+	tmpfile, _ := os.CreateTemp("", "server.*.py")
 	if _, err := tmpfile.WriteString(rstServer); err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (l *Linter) startRstServer(lib, exe string) error {
 }
 
 func findPython(exe string) (string, error) {
-	bin, err := ioutil.ReadFile(exe)
+	bin, err := os.ReadFile(exe)
 	if err != nil {
 		return "", err
 	}

--- a/internal/nlp/http.go
+++ b/internal/nlp/http.go
@@ -2,7 +2,7 @@ package nlp
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -26,7 +26,7 @@ func post(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return body, err
 	}

--- a/internal/rule/grammar.go
+++ b/internal/rule/grammar.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -150,7 +150,7 @@ func checkWithURL(text, lang, apiURL string, timeout int) (LTResult, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	result := LTResult{}
 	err = json.Unmarshal(body, &result)
 	if err != nil {


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since vale has been upgraded to Go 1.17 (662d889ce6acf942f4636075c592ee8722c6776c), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.