### PR TITLE
chore: build darwin_arm64 as well

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,12 +3,11 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/vale/main.go
     binary: vale
-    goos:
-      - windows
-      - darwin
-      - linux
-    goarch:
-      - amd64
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_amd64
+      - windows_amd64
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
In order to ease installs on M1 Macs, this adds darwin_arm64 to
goreleaser.