### PR TITLE
fix: allow `conditional` style to handle unicode

### DIFF
--- a/fixtures/checks/Conditional/test.md
+++ b/fixtures/checks/Conditional/test.md
@@ -7,3 +7,6 @@ health. We can now use WHO because it has been defined.
 The National Basketball Association (NBA) is a professional sports league.
 
 The NFL is also a sport league.
+
+The IETF: Internet Engineering Task Force does not require use of ® or ™
+for the term IETF, even though it is a trademark.

--- a/internal/check/conditional.go
+++ b/internal/check/conditional.go
@@ -87,7 +87,7 @@ func (c Conditional) Run(blk nlp.Block, f *core.File) ([]core.Alert, error) {
 	// Now we look for the antecedent.
 	locs := c.patterns[1].FindAllStringIndex(txt, -1)
 	for _, loc := range locs {
-		s := txt[loc[0]:loc[1]]
+		s := re2Loc(txt, loc)
 		if !core.StringInSlice(s, f.Sequences) && !isMatch(c.exceptRe, s) {
 			// If we've found one (e.g., "WHO") and we haven't marked it as
 			// being defined previously, send an Alert.


### PR DESCRIPTION
For instance, when the characters ® or ™ (U+00AE and U+2122) are present
in the text.

Related to #410