### PR TITLE
Consistent color reporting

### DIFF
--- a/cmd/vale/color.go
+++ b/cmd/vale/color.go
@@ -36,7 +36,7 @@ func PrintVerboseAlerts(linted []*core.File, wrap bool) bool {
 	n := len(linted)
 	if n == 1 && strings.HasPrefix(linted[0].Path, "stdin") {
 		fmt.Printf("%s %s, %s and %s in %s.\n", symbol,
-			pterm.Green(etotal), pterm.Yellow(wtotal),
+			pterm.Red(etotal), pterm.Yellow(wtotal),
 			pterm.Blue(stotal), "stdin")
 	} else {
 		fmt.Printf("%s %s, %s and %s in %d %s.\n", symbol,


### PR DESCRIPTION
`./bin/vale testdata/styles/vale/*` and `cat testdata/styles/vale/* |  ./bin/vale`
gave different error colors.

![image](https://user-images.githubusercontent.com/5798/188275021-d0a3c964-037e-4579-b40a-3a9ab3bf76d4.png)
![image](https://user-images.githubusercontent.com/5798/188275035-8dfd6538-7cee-446a-9432-6bd311331fd6.png)
