### PR TITLE
Adds Severity level to test data line template.

### DIFF
--- a/testdata/fixtures/templates/tmpl/line.tmpl
+++ b/testdata/fixtures/templates/tmpl/line.tmpl
@@ -1,6 +1,6 @@
 {{range .Files}}
 {{- $path := .Path -}}
 {{- range .Alerts -}}
-{{$path}}:{{.Line}}:{{index .Span 0}}:{{.Check}}:{{.Severity}}:{{.Message}}
+{{$path}}:{{.Line}}:{{index .Span 0}}:{{.Severity}}:{{.Check}}:{{.Severity}}:{{.Message}}
 {{end -}}
 {{end -}}


### PR DESCRIPTION
Both the CLI template

<img width="668" alt="CLI" src="https://user-images.githubusercontent.com/2521647/190294602-4dca74bc-1d4b-4598-b9b3-13bda477063e.png">

and the JSON template

<img width="825" alt="JSON" src="https://user-images.githubusercontent.com/2521647/190294620-fb8b3180-92f9-4039-b7ff-fa3c717b832b.png">

include the error `Severity: The error level.`

but the `line` does not 

<img width="798" alt="Line-without-severity" src="https://user-images.githubusercontent.com/2521647/190295083-993bf049-d71a-4375-b5c5-f2a2b9215baf.png">

so this adds it to make it consistent with the other two

<img width="811" alt="Line-with-severity" src="https://user-images.githubusercontent.com/2521647/190295165-c14c434c-535c-4240-bcf7-a14f64683664.png">

I don't know if this is the built in behavior or this is a template only for testing. 

Is this the built in behavior or only for testing?