### PR TITLE
Add OffTokens, OnTokens to support alternatives to "vale off", "vale on"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,8 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
-	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
+	golang.org/x/exp v0.0.0-20221114191408-850992195362 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHg
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/yuin/goldmark v1.4.12 h1:6hffw6vALvEDqJ19dOJvJKOoAOKe4NDaTqvd2sktGN0=
 github.com/yuin/goldmark v1.4.12/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
+golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -114,6 +116,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -48,6 +48,8 @@ type Config struct {
 	IgnoredClasses []string                   // A list of HTML classes to ignore
 	IgnoredScopes  []string                   // A list of HTML tags to ignore
 	MinAlertLevel  int                        // Lowest alert level to display
+	OffTokens      []string                   // Token to turn Vale off in a section
+	OnTokens       []string                   // Token to turn Vale on in a section
 	Vocab          []string                   // The active project
 	RuleToLevel    map[string]string          // Single-rule level changes
 	SBaseStyles    map[string][]string        // Syntax-specific base styles
@@ -89,6 +91,8 @@ func NewConfig(flags *CLIFlags) (*Config, error) {
 	cfg.Asciidoctor = make(map[string]string)
 	cfg.GChecks = make(map[string]bool)
 	cfg.MinAlertLevel = 1
+	cfg.OffTokens = []string{"vale off"}
+	cfg.OnTokens = []string{"vale on"}
 	cfg.RejectedTokens = make(map[string]struct{})
 	cfg.RuleToLevel = make(map[string]string)
 	cfg.SBaseStyles = make(map[string][]string)

--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -142,6 +142,14 @@ var coreOpts = map[string]func(*ini.Section, *Config, []string) error{
 		cfg.SkippedScopes = mergeValues(sec.Key("SkippedScopes").StringsWithShadows(","))
 		return nil
 	},
+	"OffTokens": func(sec *ini.Section, cfg *Config, args []string) error {
+		cfg.OffTokens = mergeValues(sec.Key("OffTokens").StringsWithShadows(","))
+		return nil
+	},
+	"OnTokens": func(sec *ini.Section, cfg *Config, args []string) error {
+		cfg.OnTokens = mergeValues(sec.Key("OnTokens").StringsWithShadows(","))
+		return nil
+	},
 	"IgnoredClasses": func(sec *ini.Section, cfg *Config, args []string) error {
 		cfg.IgnoredClasses = mergeValues(sec.Key("IgnoredClasses").StringsWithShadows(","))
 		return nil

--- a/testdata/fixtures/comments/test-alt-tokens.md
+++ b/testdata/fixtures/comments/test-alt-tokens.md
@@ -1,0 +1,88 @@
+<!-- prettier-ignore-start -->
+
+This is some text ACT test
+
+This is some text ACT test
+
+<!-- prettier-ignore-end -->
+
+
+<!-- vale vale.Redundancy = NO -->
+
+This is some text ACT test
+
+<!-- vale vale.Redundancy = YES -->
+
+This is some text ACT test
+
+<!-- vale demo.Ending-Preposition = NO -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale demo.Ending-Preposition = YES -->
+
+This is a sentance of.
+
+1. Consider the following `deployment.yaml` file.
+
+   ```yaml
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: my-nginx-svc
+     labels:
+       app: nginx
+   spec:
+     type: LoadBalancer
+     ports:
+     - port: 80
+     selector:
+       app: nginx
+   ---
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: my-nginx
+     labels:
+       app: nginx
+   spec:
+     replicas: 3
+     selector:
+       matchLabels:
+         app: nginx
+     template:
+       metadata:
+         labels:
+           app: nginx
+       spec:
+         containers:
+         - name: nginx
+           image: nginx:1.7.9
+           ports:
+           - containerPort: 80
+   ```
+
+2. few other steps.
+<!-- prettier-ignore-start -->
+1. This is a sentance of.
+   ```bash
+   SSH should not typically be used within containers.
+   Ensure that non-SSH services are not using port 22.
+   ```
+<!-- prettier-ignore-end -->
+
+something else.
+
+This is a sentance of.
+
+- Unordered list example.
+<!-- prettier-ignore-start -->
+- This is a sentance of.
+<!-- prettier-ignore-end -->
+- one more item.
+
+<!-- vale demo.Raw = NO -->
+
+Internal Links [must not use `.html`](../index.html)

--- a/testdata/fixtures/configs/.vale.ini
+++ b/testdata/fixtures/configs/.vale.ini
@@ -1,5 +1,7 @@
 StylesPath = ../../styles
 MinAlertLevel = error
+OffTokens = vale off, prettier-ignore-start
+OnTokens = vale on, prettier-ignore-end
 
 [*.md]
 BasedOnStyles = proselint

--- a/testdata/fixtures/configs/ini/.vale.ini
+++ b/testdata/fixtures/configs/ini/.vale.ini
@@ -1,5 +1,8 @@
 StylesPath = styles
 MinAlertLevel = suggestion
+OffTokens = vale off, prettier-ignore-start
+OnTokens = vale on, prettier-ignore-end
+
 
 [*.md]
 BasedOnStyles = Joblint


### PR DESCRIPTION
This allows to disable linters as a whole for larger sections of text.

Typically, when I am quoting, I want to turn off vale and prettier in order to avoid messing with the source elements.

Example usage

```vale.ini
OffTokens = vale off, prettier-ignore-start, linters off
OnTokens = vale on, prettier-ignore-end, linters on
```