### PR TITLE
feat(config): expand ~ to home directory

### DIFF
--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -98,7 +98,7 @@ var coreOpts = map[string]func(*ini.Section, *Config, []string) error{
 			cfg.StylesPath = basePath
 		} else {
 			entry := sec.Key("StylesPath").MustString("")
-			canidate := normalizePath(filepath.FromSlash(entry))
+			canidate := filepath.FromSlash(entry)
 
 			cfg.StylesPath = determinePath(cfg.Flags.Path, canidate)
 			if !FileExists(cfg.StylesPath) {

--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -98,7 +98,7 @@ var coreOpts = map[string]func(*ini.Section, *Config, []string) error{
 			cfg.StylesPath = basePath
 		} else {
 			entry := sec.Key("StylesPath").MustString("")
-			canidate := filepath.FromSlash(entry)
+			canidate := normalizePath(filepath.FromSlash(entry))
 
 			cfg.StylesPath = determinePath(cfg.Flags.Path, canidate)
 			if !FileExists(cfg.StylesPath) {

--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -237,7 +237,23 @@ func SplitLines(data []byte, atEOF bool) (adv int, token []byte, err error) {
 	return 0, nil, nil
 }
 
+func normalizePath(path string) string {
+	// expand tilde
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return homedir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(homedir, path[2:])
+	}
+	return path
+}
+
 func determinePath(configPath string, keyPath string) string {
+	// expand tilde at this point as this is where user-provided paths are provided
+	keyPath = normalizePath(keyPath)
 	if !IsDir(configPath) {
 		configPath = filepath.Dir(configPath)
 	}

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -44,5 +47,39 @@ func TestPhrase(t *testing.T) {
 		if result != output {
 			t.Errorf("expected = %v, got = %v", output, result)
 		}
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		t.Log("os.UserHomeDir failed, will not proceed with tests")
+		return
+	}
+	stylesPathInput := "~/.vale"
+	expectedOutput := filepath.Join(homedir, ".vale")
+	result := normalizePath(stylesPathInput)
+	if result != expectedOutput {
+		t.Errorf("expected = %v, got = %v", expectedOutput, result)
+	}
+	stylesPathInput, err = ioutil.TempDir("", "vale_test")
+	if err != nil {
+		t.Log("ioutil.TempDir failed, will not proceed with tests")
+		return
+	}
+	expectedOutput = stylesPathInput
+	result = normalizePath(stylesPathInput)
+	if result != expectedOutput {
+		t.Errorf("expected = %v, got = %v", expectedOutput, result)
+	}
+	stylesPathInput, err = ioutil.TempDir("", "vale~test")
+	if err != nil {
+		t.Log("ioutil.TempDir failed in second case, will not proceed with tests")
+		return
+	}
+	expectedOutput = stylesPathInput
+	result = normalizePath(stylesPathInput)
+	if result != expectedOutput {
+		t.Errorf("expected = %v, got = %v", expectedOutput, result)
 	}
 }

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,9 +61,9 @@ func TestNormalizePath(t *testing.T) {
 	if result != expectedOutput {
 		t.Errorf("expected = %v, got = %v", expectedOutput, result)
 	}
-	stylesPathInput, err = ioutil.TempDir("", "vale_test")
+	stylesPathInput, err = os.MkdirTemp("", "vale_test")
 	if err != nil {
-		t.Log("ioutil.TempDir failed, will not proceed with tests")
+		t.Log("os.MkdirTemp failed, will not proceed with tests")
 		return
 	}
 	expectedOutput = stylesPathInput
@@ -72,9 +71,9 @@ func TestNormalizePath(t *testing.T) {
 	if result != expectedOutput {
 		t.Errorf("expected = %v, got = %v", expectedOutput, result)
 	}
-	stylesPathInput, err = ioutil.TempDir("", "vale~test")
+	stylesPathInput, err = os.MkdirTemp("", "vale~test")
 	if err != nil {
-		t.Log("ioutil.TempDir failed in second case, will not proceed with tests")
+		t.Log("os.MkdirTemp failed in second case, will not proceed with tests")
 		return
 	}
 	expectedOutput = stylesPathInput


### PR DESCRIPTION
Hello there.

Improve usability by supporting this common pattern. Allows  setting explicit paths for global vale configs that are applied to all profiles in a company.

Might help with !94