### PR TITLE
fix: allow for more generic errors in loadPkg

### DIFF
--- a/cmd/vale/sync.go
+++ b/cmd/vale/sync.go
@@ -74,7 +74,7 @@ func readPkg(pkg, path string, idx int) error {
 }
 
 func loadPkg(name, urlOrPath, styles string, index int) error {
-	if fileInfo, err := os.Stat(urlOrPath); !os.IsNotExist(err) {
+	if fileInfo, err := os.Stat(urlOrPath); err == nil {
 		if fileInfo.IsDir() {
 			parentDirectory := strings.TrimSuffix(urlOrPath, fmt.Sprintf("%c%s", os.PathSeparator, name))
 			return installPkg(parentDirectory, name, styles, index)


### PR DESCRIPTION
fix: allow for more generic errors in loadPkg

os.Stat() was receiving an error but the conditional was only looking for a "not exist" error. This change makes it so that we skip if there are ANY errors.

Related to #542 