### PR TITLE
(MAINT) Add tests for PowerShell code linting

### DIFF
--- a/testdata/features/lint.feature
+++ b/testdata/features/lint.feature
@@ -254,6 +254,17 @@ Feature: Lint
             """
         And the exit status should be 0
 
+    Scenario: Lint a PowerShell file
+        When I lint "test.ps1"
+        Then the output should contain exactly:
+            """
+            test.ps1:2:24:vale.Annotations:'XXX' left in text
+            test.ps1:4:9:vale.Annotations:'NOTE' left in text
+            test.ps1:5:9:vale.Annotations:'FIXME' left in text
+            test.ps1:8:26:vale.Annotations:'TODO' left in text
+            """
+        And the exit status should be 0
+
     Scenario: Lint a Lua file
         When I lint "test.lua"
         Then the output should contain exactly:

--- a/testdata/fixtures/formats/test.ps1
+++ b/testdata/fixtures/formats/test.ps1
@@ -1,0 +1,9 @@
+function Test-Vale {
+    "This is a test" # XXX: this is a line comment.
+    <#
+        NOTE: this is a multiline comment
+        FIXME: this is too!
+    #>
+    "TODO is yet another test"
+    "FIXME Final Test" # TODO: Here's a comment
+}


### PR DESCRIPTION
This change adds spec definitions for the linting feature that checks PowerShell code comments.