### PR TITLE
(GH-597) Find config in home folder as last resort

### DIFF
--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -212,9 +212,10 @@ func loadINI(cfg *Config, dry bool) error {
 	return processConfig(uCfg, cfg, sources, dry)
 }
 
-// loadConfig loads the .vale file. It checks the current directory up to the
-// user's home directory, stopping on the first occurrence of a .vale or _vale
-// file.
+// loadConfig loads the .vale file. It checks the ancestors of the current
+// directory, stopping on the first occurrence of a .vale or _vale file. If
+// no ancestor of the current directory has a configuration file, it checks
+// the user's home directory for a configuration file.
 func loadConfig(names []string) (string, error) {
 	var parent string
 
@@ -237,6 +238,18 @@ func loadConfig(names []string) (string, error) {
 			break
 		}
 		cwd = parent
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	for _, name := range names {
+		loc := path.Join(homeDir, name)
+		if FileExists(loc) && !IsDir(loc) {
+			return loc, nil
+		}
 	}
 
 	return "", nil


### PR DESCRIPTION
Prior to this change, the [documentation][01] noted that when no closer configuration can be found, Vale will default to using the configuration file in the user's home directory. However, the implementation for the `loadConfig()` function only recursed through the current working directory's ancestors.

This meant that if the working directory didn't have the user's home directory as an ancestor, no configuration would be found and the user would get an error even when they had defined a configuration file in their home directory.

This change:

- Updates the `loadConfig()` function to explicitly search the user's home directory if no configuration file is discovered in an ancestor folder of the current working directory.
- Maintains all other prior functionality.
- Resolves #597.

[01]: https://vale.sh/docs/topics/config/#search-process