### PR TITLE
feat: add clojure support

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -17,6 +17,11 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockStart": `(/\*.*)`,
 		"blockEnd":   `(.*\*/)`,
 	},
+	".clj": {
+		"inline":     `(;+.+)`,
+		"blockStart": `$^`,
+		"blockEnd":   `$^`,
+	},
 	".css": {
 		"inline":     `(/\*.+\*/)`,
 		"blockStart": `(/\*.*)`,
@@ -71,6 +76,7 @@ var FormatByExtension = map[string][]string{
 	`\.(?:adoc|asciidoc|asc)$`:                    {".adoc", "markup"},
 	`\.(?:cpp|cc|c|cp|cxx|c\+\+|h|hpp|h\+\+)$`:    {".c", "code"},
 	`\.(?:cs|csx)$`:                               {".c", "code"},
+	`\.(?:clj|cljs|cljc|cljd)$`:                   {".clj", "code"},
 	`\.(?:css)$`:                                  {".css", "code"},
 	`\.(?:go)$`:                                   {".c", "code"},
 	`\.(?:html|htm|shtml|xhtml)$`:                 {".html", "markup"},

--- a/internal/lint/comments.go
+++ b/internal/lint/comments.go
@@ -30,6 +30,13 @@ var patterns = map[string]map[string][]*regexp.Regexp{
 			regexp.MustCompile(`(.*\*/)`),
 		},
 	},
+	".clj": {
+		"inline": []*regexp.Regexp{
+			regexp.MustCompile(`(?s);+(.+)`),
+		},
+		"blockStart": []*regexp.Regexp{},
+		"blockEnd":   []*regexp.Regexp{},
+	},
 	".css": {
 		"inline": []*regexp.Regexp{
 			regexp.MustCompile(`(?s)/\*(.+)\*/`),

--- a/testdata/features/lint.feature
+++ b/testdata/features/lint.feature
@@ -146,6 +146,17 @@ Feature: Lint
             """
         And the exit status should be 0
 
+    Scenario: Lint a Clojure file
+        When I lint "test.clj"
+        Then the output should contain exactly:
+            """
+            test.clj:3:6:vale.Annotations:'NOTE' left in text
+            test.clj:5:15:vale.Annotations:'TODO' left in text
+            test.clj:7:6:vale.Annotations:'FIXME' left in text
+            test.clj:9:11:vale.Annotations:'XXX' left in text
+            """
+        And the exit status should be 0
+
     Scenario: Lint a JSX file
         When I lint "test.jsx"
         Then the output should contain exactly:

--- a/testdata/fixtures/formats/test.clj
+++ b/testdata/fixtures/formats/test.clj
@@ -1,0 +1,9 @@
+(ns test)
+
+;;;; NOTE: Section comment
+
+(defn TODO ;; TODO: double ;; comment
+  "FIXME: Unfortunately no linting for docstrings"
+  ;; FIXME: But linting for comments!
+  []
+  'XXX) ; XXX: single ; comment


### PR DESCRIPTION
Used #564 as a reference for the tests. 
Running `make test` failed with the same errors observed on the main branch, so I'm assuming they were unrelated to this change.

```
Failing Scenarios:
cucumber features/config.feature:108 # Scenario: Non-Existent Config
cucumber features/lint.feature:63 # Scenario: Lint a DITA file
cucumber features/scopes.feature:73 # Scenario: Heading
```

Thanks for vale 🥳 !
