### PR TITLE
fix: normalizePath tilde expansion on Windows

### DIFF
--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -233,7 +233,7 @@ func normalizePath(path string) string {
 	}
 	if path == "~" {
 		return homedir
-	} else if strings.HasPrefix(path, "~/") {
+	} else if strings.HasPrefix(path, filepath.FromSlash("~/")) {
 		path = filepath.Join(homedir, path[2:])
 	}
 	return path

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -55,7 +55,7 @@ func TestNormalizePath(t *testing.T) {
 		t.Log("os.UserHomeDir failed, will not proceed with tests")
 		return
 	}
-	stylesPathInput := "~/.vale"
+	stylesPathInput := filepath.FromSlash("~/.vale")
 	expectedOutput := filepath.Join(homedir, ".vale")
 	result := normalizePath(stylesPathInput)
 	if result != expectedOutput {


### PR DESCRIPTION
normalizePath sometimes gets backslash paths as input. 
In such case it will not be able to act on the `~/` prefix, since it will be `\~` instead. 
FromSlash will provide the correct variant.

An example where the error happens:

With `.vale.ini`:

```ini
StylesPath = ~/.vale/styles
```

When running Vale:

```
The path 'C:\Users\...\Code\~\.vale\styles' does not exist.
```

The test was wrongly failing after this change. The `normalizePath` callers tend to provide `FromSlash`'ed inputs, so the test has been adapted accordingly.