### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -X main.version=$ltag" -o 
 
 FROM alpine
 
-RUN apk add --no-cache --update \
+RUN apk add --no-cache \
     py3-docutils \
     asciidoctor
 


### PR DESCRIPTION
In Alpine Linux's `apk`, the use of `--no-cache` ensures the index is fetched every time, making a local cache unnecessary. Therefore, combining it with `--update` is redundant and should be removed to prevent temporary files in the Docker image.