### PR TITLE
Feat: Add Optional Custom Message to Script Match

### DIFF
--- a/internal/check/script.go
+++ b/internal/check/script.go
@@ -55,32 +55,48 @@ func (s Script) Run(blk nlp.Block, _ *core.File) ([]core.Alert, error) {
 		return alerts, core.NewE201FromTarget(err.Error(), "script", s.path)
 	}
 
-	for _, loc := range toLocation(compiled.Get("matches").Array()) {
-		match := blk.Text[loc[0]:loc[1]]
+	for _, match := range parseMatches(compiled.Get("matches").Array()) {
+		matchText := blk.Text[match["begin"].(int):match["end"].(int)]
+		matchLoc := []int{match["begin"].(int), match["end"].(int)}
 		// NOTE: We can't call `makeAlert` here because `script`-based rules
 		// don't use our custom regexp2 library, which means the offsets
 		// (`re2loc`) will be off.
 		a := core.Alert{
-			Check: s.Name, Severity: s.Level, Span: loc, Link: s.Link,
-			Match: match, Action: s.Action}
+			Check:    s.Name,
+			Severity: s.Level,
+			Span:     matchLoc,
+			Link:     s.Link,
+			Match:    matchText,
+			Action:   s.Action}
 
-		a.Message, a.Description = formatMessages(s.Message, s.Description, match)
+		if matchMsg, ok := match["message"].(string); ok {
+			a.Message, a.Description = formatMessages(matchMsg, s.Description, matchText)
+		} else {
+			a.Message, a.Description = formatMessages(s.Message, s.Description, matchText)
+		}
+
 		alerts = append(alerts, a)
 	}
 
 	return alerts, nil
 }
 
-func toLocation(a []interface{}) [][]int {
-	locs := [][]int{}
+func parseMatches(a []interface{}) []map[string]interface{} {
+	matches := []map[string]interface{}{}
 	for _, i := range a {
 		m, _ := i.(map[string]interface{})
-		locs = append(locs, []int{
-			int(m["begin"].(int64)),
-			int(m["end"].(int64)),
-		})
+		match := map[string]interface{}{
+			"begin": int(m["begin"].(int64)),
+			"end":   int(m["end"].(int64)),
+		}
+
+		if msg, ok := m["message"].(string); ok {
+			match["message"] = msg
+		}
+
+		matches = append(matches, match)
 	}
-	return locs
+	return matches
 }
 
 // Fields provides access to the internal rule definition.


### PR DESCRIPTION
# 📖 Description
This PR implements the feature suggested in https://github.com/errata-ai/vale/discussions/679

The `matches` object populated by a Tengolang script in a script based rule can now also have an optional `message` per match. This way, a single script-based rule can find several similar issues while still providing a precise error message to the user on a per-match basis.