### PR TITLE
Julia Support

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -66,6 +66,11 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockStart": `(^=begin)`,
 		"blockEnd":   `(^=end)`,
 	},
+	".jl": { // Julia
+		"inline":     `(#.+)`,
+		"blockStart": `(#=)`,
+		"blockEnd":   `(=#)`,
+	}
 }
 
 // FormatByExtension associates a file extension with its "normed" extension
@@ -99,6 +104,7 @@ var FormatByExtension = map[string][]string{
 	`\.(?:xml)$`:                                  {".xml", "markup"},
 	`\.(?:dita)$`:                                 {".dita", "markup"},
 	`\.(?:org)$`:                                  {".org", "markup"},
+	`\.(?:jl)$`:                                   {".jl", "code"},
 }
 
 // FormatFromExt takes a file extension and returns its [normExt, format]

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -67,9 +67,9 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockEnd":   `(^=end)`,
 	},
 	".jl": { // Julia
-		"inline":     `(#.+)`,
-		"blockStart": `(#=)`,
-		"blockEnd":   `(=#)`,
+		"inline":     `(#.*|".+"|"{3}.+"{3})`, // Comments staring with #, single and tripple one line strings
+		"blockStart": `(#=|"{3})`, // the triple-string might still have @doc raw or just raw upfront, is that ok here, when I do not use ^?
+		"blockEnd":   `(=#|"{3})`,
 	},
 }
 

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -70,7 +70,7 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"inline":     `(#.+)`,
 		"blockStart": `(#=)`,
 		"blockEnd":   `(=#)`,
-	}
+	},
 }
 
 // FormatByExtension associates a file extension with its "normed" extension

--- a/testdata/fixtures/formats/test.jl
+++ b/testdata/fixtures/formats/test.jl
@@ -23,9 +23,19 @@ function g(x)
     return x^3
 end
 
+@doc raw"""
+    h(x)
+
+I am an example doc string, which has one further macro (`@doc`) upfront,
+there might also be other macros or string types (besides raw and doc) upfront.
+"""
+function h(x)
+    return x^4
+end
+
 # single strings could also be doc strings I think.
 
-function h(x)
+function i(x)
     println("I am just a single line string")
-    return x^4
+    return x^5
 end

--- a/testdata/fixtures/formats/test.jl
+++ b/testdata/fixtures/formats/test.jl
@@ -1,0 +1,31 @@
+# This is a single comment line
+
+#=
+  I am a mlutiline comment, but i use words that are
+  obviously maybe avoidable
+=#
+
+"""
+    f(x)
+
+I am a simple doc string of a quadratic function.
+This is Markdown and hence the first line is just a code block
+"""
+f(x) = x^2
+
+raw"""
+    g(x)
+
+I am an example doc string, which is also in Markdown,
+just that math is in ``g(x) = x^3`` two backticks
+"""
+function g(x)
+    return x^3
+end
+
+# single strings could also be doc strings I think.
+
+function h(x)
+    println("I am just a single line string")
+    return x^4
+end


### PR DESCRIPTION
This PR aims to add Julia support (resolves #729).

I would like to also try to resolve #728 if possible. I added a test file, but I am unsure how to accomplish the string part.
I am also not sure whether my code is correct, since I have never programmed in Go before nor did I have the time to install that, so I just tried to mimic what was there.

For the doc strings, see https://docs.julialang.org/en/v1/manual/documentation/ , maybe it is really just enough to consider strings and multiline strings as text.

The only caveats there are

* `"$(a) and $a"` is a string where the current value of `a` is interpolated twice (placed in there
* inline math in Julia flavoured Markdown is done with two backticks like ``` raw"``\frac{1}{2}``" ```, where the keyword `raw` is just used so that I do not have to escape the backslash.

(but maybe the two backpacks can be added to some ignore in the `.vale.ini` like other Markdown inline math ones as well)

Thanks for writing such a nice package, I already use it on a Julia Package (Markdown) Documentation I am writing.