### PR TITLE
feat: add comment syntax for switching styles

### DIFF
--- a/internal/core/file.go
+++ b/internal/core/file.go
@@ -16,7 +16,9 @@ import (
 	"github.com/errata-ai/vale/v2/internal/nlp"
 )
 
-var commentControlRE = regexp.MustCompile(`^vale (.+\..+) = (YES|NO)$`)
+var commentControlRE = regexp.MustCompile(`^vale (.+\..+|[^.]+) = (YES|NO|on|off)$`)
+
+var commentStyleRE = regexp.MustCompile(`^vale styles? = (.*)$`)
 
 // A File represents a linted text file.
 type File struct {
@@ -293,19 +295,33 @@ func (f *File) UpdateComments(comment string) {
 	} else if commentControlRE.MatchString(comment) {
 		check := commentControlRE.FindStringSubmatch(comment)
 		if len(check) == 3 {
-			f.Comments[check[1]] = check[2] == "NO"
+			f.Comments[check[1]] = (check[2] == "NO" || check[2] == "off")
+		}
+	} else if commentStyleRE.MatchString(comment) {
+		for _, style := range f.BaseStyles {
+			f.Comments[style] = true
+		}
+		check := commentStyleRE.FindStringSubmatch(comment)
+		for _, style := range strings.Split(check[1], ", ") {
+			f.Comments[style] = false
 		}
 	}
 }
 
 // QueryComments checks if there has been an in-text comment for this check.
 func (f *File) QueryComments(check string) bool {
-	if !f.Comments["off"] {
-		if status, ok := f.Comments[check]; ok {
-			return status
+	if f.Comments["off"] {
+		return true
+	}
+	if style, _, ok := strings.Cut(check, "."); ok {
+		if status, _ := f.Comments[style]; status {
+			return true
 		}
 	}
-	return f.Comments["off"]
+	if status, _ := f.Comments[check]; status {
+		return true
+	}
+	return false
 }
 
 // ResetComments resets the state of all checks back to active.


### PR DESCRIPTION
This adds some comment syntax for controlling styles.

Individual styles can be switched on and off:
```
<!-- vale StyleName1 = YES -->
<!-- vale StyleName2 = NO -->
```
For a rule to be effective both the rule and the style has to be enabled.

`on` and `off` is accepted in addition to `YES` and `NO`
```
<!-- vale StyleName1 = on -->
<!-- vale StyleName2 = off -->
```

Styles can be set (enabling them and switching off any other styles):
```
<!-- vale style = StyleName1 -->
<!-- vale styles = StyleName1, StyleName2 -->
```