### PR TITLE
feat: add comment syntax for switching styles

### DIFF
--- a/internal/core/file.go
+++ b/internal/core/file.go
@@ -15,7 +15,9 @@ import (
 	"github.com/errata-ai/vale/v3/internal/nlp"
 )
 
-var commentControlRE = regexp.MustCompile(`^vale (.+\..+) = (YES|NO)$`)
+var commentControlRE = regexp.MustCompile(`^vale (.+\..+|[^.]+) = (YES|NO|on|off)$`)
+
+var commentStyleRE = regexp.MustCompile(`^vale styles? = (.*)$`)
 
 // A File represents a linted text file.
 type File struct {
@@ -314,19 +316,33 @@ func (f *File) UpdateComments(comment string) {
 	} else if commentControlRE.MatchString(comment) {
 		check := commentControlRE.FindStringSubmatch(comment)
 		if len(check) == 3 {
-			f.Comments[check[1]] = check[2] == "NO"
+			f.Comments[check[1]] = (check[2] == "NO" || check[2] == "off")
+		}
+	} else if commentStyleRE.MatchString(comment) {
+		for _, style := range f.BaseStyles {
+			f.Comments[style] = true
+		}
+		check := commentStyleRE.FindStringSubmatch(comment)
+		for _, style := range strings.Split(check[1], ", ") {
+			f.Comments[style] = false
 		}
 	}
 }
 
 // QueryComments checks if there has been an in-text comment for this check.
 func (f *File) QueryComments(check string) bool {
-	if !f.Comments["off"] {
-		if status, ok := f.Comments[check]; ok {
-			return status
+	if f.Comments["off"] {
+		return true
+	}
+	if style, _, ok := strings.Cut(check, "."); ok {
+		if status := f.Comments[style]; status {
+			return true
 		}
 	}
-	return f.Comments["off"]
+	if status := f.Comments[check]; status {
+		return true
+	}
+	return false
 }
 
 // ResetComments resets the state of all checks back to active.

--- a/testdata/features/comments.feature
+++ b/testdata/features/comments.feature
@@ -8,6 +8,24 @@ Feature: Comments
     test.md:25:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
     test.md:77:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
     test.md:87:16:demo.Raw:Link "[must not use `.html`](../index.html)" must use the .md file extension.
+    test.md:91:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:93:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.md:103:19:vale.Redundancy:'ACT test' is redundant
+    test.md:109:19:vale.Redundancy:'ACT test' is redundant
+    test.md:109:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:111:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.md:115:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:117:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.md:127:19:vale.Redundancy:'ACT test' is redundant
+    test.md:133:19:vale.Redundancy:'ACT test' is redundant
+    test.md:133:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:135:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.md:139:19:vale.Redundancy:'ACT test' is redundant
+    test.md:145:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:147:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.md:151:19:vale.Redundancy:'ACT test' is redundant
+    test.md:151:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.md:153:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
     """
 
   Scenario: reStructuredText
@@ -17,6 +35,24 @@ Feature: Comments
     test.rst:15:19:vale.Redundancy:'ACT test' is redundant
     test.rst:19:19:vale.Redundancy:'ACT test' is redundant
     test.rst:25:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:41:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:43:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:53:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:59:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:59:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:61:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:65:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:67:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:77:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:83:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:83:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:85:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:89:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:95:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:97:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
+    test.rst:101:19:vale.Redundancy:'ACT test' is redundant
+    test.rst:101:48:demo.Ending-Preposition:Don't end a sentence with 'for.'
+    test.rst:103:20:demo.Ending-Preposition:Don't end a sentence with 'of.'
     """
 
   Scenario: AsciiDoc

--- a/testdata/fixtures/comments/test.md
+++ b/testdata/fixtures/comments/test.md
@@ -85,3 +85,69 @@ This is a sentance of.
 <!-- vale demo.Raw = NO -->
 
 Internal Links [must not use `.html`](../index.html)
+
+<!-- vale vale = off -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale demo = off -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale vale = on -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale demo = on -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale vale = NO -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale demo = NO -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale vale = YES -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale demo = YES -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale style = vale -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale style = demo -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.
+
+<!-- vale styles = vale, demo -->
+
+This is some text ACT test. This is a sentence for.
+
+This is a sentance of.

--- a/testdata/fixtures/comments/test.rst
+++ b/testdata/fixtures/comments/test.rst
@@ -35,3 +35,69 @@ The default types are as follows:
 -  Virtual
 
 .. vale on
+
+.. vale vale = off
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale demo = off
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale vale = on
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale demo = on
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale vale = NO
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale demo = NO
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale vale = YES
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale demo = YES
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale style = vale
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale style = demo
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.
+
+.. vale styles = vale, demo
+
+This is some text ACT test. This is a sentance for.
+
+This is a sentance of.


### PR DESCRIPTION
This is a follow-up to #748 with tests included.

Individual styles can be switched on and off:
```
<!-- vale StyleName1 = YES -->
<!-- vale StyleName2 = NO -->
```
For a rule to be effective both the rule and the style has to be enabled.

`on` and `off` is accepted in addition to `YES` and `NO`
```
<!-- vale StyleName1 = on -->
<!-- vale StyleName2 = off -->
```

Styles can be set (enabling them and switching off any other styles):
```
<!-- vale style = StyleName1 -->
<!-- vale styles = StyleName1, StyleName2 -->
```