### PR TITLE
fix: Add support for multi platform image builds in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # See https://cloud.docker.com/repository/docker/jdkato/vale
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
+ARG GOLANG_VER=1.21
+FROM golang:${GOLANG_VER}-alpine AS build
 
 # TODO: DITA / XML:
 #    openjdk11 \
@@ -18,9 +19,8 @@ WORKDIR /app
 ENV CGO_ENABLED=1
 
 ARG ltag
-ARG TARGETOS TARGETARCH
 
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-s -w -X main.version=$ltag" -o /app/vale ./cmd/vale
+RUN go build -ldflags "-s -w -X main.version=$ltag" -o /app/vale ./cmd/vale
 
 FROM alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-# See https://cloud.docker.com/repository/docker/jdkato/vale
+# syntax=docker/dockerfile:1
 ARG GOLANG_VER=1.21
 FROM golang:${GOLANG_VER}-alpine AS build
+
+# See https://cloud.docker.com/repository/docker/jdkato/vale
 
 # TODO: DITA / XML:
 #    openjdk11 \

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ GOLANG_CROSS_VERSION  ?= v0.2.0
 SYSROOT_DIR     ?= sysroots
 SYSROOT_ARCHIVE ?= sysroots.tar.bz2
 
-LAST_TAG=$(shell git describe --abbrev=0 --tags)
-CURR_SHA=$(shell git rev-parse --verify HEAD)
+LAST_TAG := $(shell git describe --abbrev=0 --tags)
+CURR_SHA := $(shell git rev-parse --verify HEAD)
 
-LDFLAGS=-ldflags "-s -w -X main.version=$(LAST_TAG)"
+LDFLAGS := -ldflags "-s -w -X main.version=$(LAST_TAG)"
+
+DOCKER_BUILD_TARGETS := linux/arm64,linux/amd64
+DOCKER_USER  ?= jdkato
 
 .PHONY: data test lint install rules setup bench compare release choco-cross
 
@@ -53,15 +56,24 @@ test:
 	cd testdata && cucumber --format progress && cd -
 
 docker:
-	docker login -u jdkato -p ${DOCKER_PASS}
+	@echo ${DOCKER_PASS} | docker login -u ${DOCKER_USER} --password-stdin
+
+	# Ignore command failure
+	-docker buildx create \
+		--name container-builder \
+		--driver docker-container \
+		--use --bootstrap
+
 	docker buildx build \
-	--build-arg ltag=${LAST_TAG} \
-	--platform=linux/amd64 \
-	--file Dockerfile \
-	--tag jdkato/vale:${LAST_TAG} \
-	--tag jdkato/vale:latest \
-	--push \
-	.
+		--build-arg ltag=${LAST_TAG} \
+		--platform=${DOCKER_BUILD_TARGETS} \
+		--file Dockerfile \
+		--tag ${DOCKER_USER}/vale:${LAST_TAG} \
+		--tag ${DOCKER_USER}/vale:latest \
+		--push \
+		.
+
+	docker buildx rm container-builder #Tidy up
 
 choco-cross:
 	@docker run \


### PR DESCRIPTION
Makefile changes:

1. Add new variable  for Docker user name, called DOCKER_USER, defaults to "jdkato"
1. Add new variable for list of platforms, called DOCKER_BUILD_TARGETS
1. Add new docker buildx commands to create and remove docker build containers
1. Modify docker buildx build command to support DOCKER_BUILD_TARGETS and DOCKER_USER
1. Change the way docker login is done (--password-stdin) to avoid annoying security warning
1. Change LAST_TAG, LDFLAGS, and CURR_SHA to simply expanded variables to improve performance

Dockerfile changes

1. Add new ARG value for Go version, called GOLANG_VER, defaults to "1.21"
1. Remove GOOS=$TARGETOS GOARCH=$TARGETARCH and related definitions
1. Remove "--platform=$BUILDPLATFORM" in FROM line

## Assumptions:

Building and pushing Docker images is a manual process that takes place on the developer’s machine.

Integration into the GitHub actions would be desirable, but will require additional work.

## Testing Notes:

Tested in a Git checkout with the command

```sh
make DOCKER_USER=<Docker Hub Username> DOCKER_PASS='<Docker Hub Token>' docker
docker container run -it --rm <Docker Hub Username>/vale --version
```

Tested on macOS host. it was necessary to disable  Rosettta support

Related to https://github.com/errata-ai/vale/issues/859