### PR TITLE
feat: zig support

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -54,7 +54,7 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockEnd":   `(.*-\})`,
 	},
 	".zig": {
-		"inline":     `(//.+)`,
+		"inline":     `(/{2,3}.+)`,
 		"blockStart": `$^`,
 		"blockEnd":   `$^`,
 	},

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -54,7 +54,7 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockEnd":   `(.*-\})`,
 	},
 	".zig": {
-		"inline":     `(/{2,3}.+)`,
+		"inline":     `(/{2,3}.+)|(//!.+)`,
 		"blockStart": `$^`,
 		"blockEnd":   `$^`,
 	},

--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -53,6 +53,11 @@ var CommentsByNormedExt = map[string]map[string]string{
 		"blockStart": `(\{-.*)`,
 		"blockEnd":   `(.*-\})`,
 	},
+	".zig": {
+		"inline":     `(//.+)`,
+		"blockStart": `$^`,
+		"blockEnd":   `$^`,
+	},
 }
 
 // FormatByExtension associates a file extension with its "normed" extension
@@ -89,6 +94,7 @@ var FormatByExtension = map[string][]string{
 	`\.(?:txt)$`:       {".txt", "text"},
 	`\.(?:xml)$`:       {".xml", "markup"},
 	`\.(?:yaml|yml)$`:  {".yml", "code"},
+	`\.(?:zig)$`:  	    {".zig", "code"},
 }
 
 // FormatFromExt takes a file extension and returns its [normExt, format]

--- a/testdata/features/lint.feature
+++ b/testdata/features/lint.feature
@@ -380,3 +380,11 @@ Feature: Lint
             test.mdx:46:3:vale.Annotations:'TODO' left in text
             """
         And the exit status should be 0
+
+    Scenario: Lint a zig file
+        When I lint "test.zig"
+        Then the output should contain exactly:
+            """
+            test.zig:7:9:vale.Annotations:'XXX' left in text
+            test.zig:10:9:vale.Annotations:'TODO' left in text
+            """

--- a/testdata/fixtures/formats/test.zig
+++ b/testdata/fixtures/formats/test.zig
@@ -1,0 +1,12 @@
+//! top-level doc-comment
+
+// normal comment
+
+/// doc-comment
+const Timestamp = struct {
+    /// XXX: A comment in a struct
+    nanos: u32,
+
+    /// TODO: Ad function
+    pub fn unixEpoch() Timestamp {}
+};


### PR DESCRIPTION
This is related to #929. I tried adding my own zig support, not sure if I did everything right.

I just want to note that zig does only support line comments (`//` or `///` or `//!`).