### PR TITLE
fix: check `qErr != nil` but return a nil value error `err`

### DIFF
--- a/internal/lint/code/comments.go
+++ b/internal/lint/code/comments.go
@@ -112,7 +112,7 @@ func GetComments(source []byte, lang *Language) ([]Comment, error) {
 	for _, query := range lang.Queries {
 		q, qErr := sitter.NewQuery([]byte(query), lang.Parser)
 		if qErr != nil {
-			return comments, err
+			return comments, qErr
 		}
 		comments = append(comments, engine.run(q, source)...)
 	}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -344,7 +344,7 @@ func (l *Linter) setup() error {
 func (l *Linter) teardown() error {
 	for _, pid := range l.pids {
 		if p, err := os.FindProcess(pid); err == nil {
-			if p.Kill() != nil {
+			if err := p.Kill(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
the p.Kill() return an error, but return a nil


I create a linter to detect code that returns a non-relevant nilness error bug. I checked the top 1000 GitHub Go repositories and found this, all result listed in https://github.com/alingse/sundrylint/issues/4