### PR TITLE
fix: allow optional language in code block

### DIFF
--- a/internal/lint/rst.go
+++ b/internal/lint/rst.go
@@ -14,7 +14,7 @@ import (
 //
 // reCodeBlock is used to convert Sphinx-style code directives to the regular
 // `::` for rst2html, including the use of runtime options (e.g., :caption:).
-var reCodeBlock = regexp.MustCompile(`.. (?:raw|code(?:-block)?):: (?:[\w-]+)(?:\s+:\w+: .+)*`)
+var reCodeBlock = regexp.MustCompile(`\.\. (?:raw|code(?:-block)?):: *(?:[\w-]+)?(?:\s+:\w+:.*)*`)
 
 // We replace custom directives with `.. code::`.
 //


### PR DESCRIPTION
According to [sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block) the language name of a code block is optional. By the way some directive options may have no argument.

This PR fix update the regular expression `reCodeBlock` with the following changes:

 * spaces patterns before language name and option values are expected 0 or many times
 * language name pattern is expected 0 or 1 time
 * directive dots are only dots and not any character
 * rst argument of directive option can be optional