### PR TITLE
feat: add replace action to default Vale.Terms rule

### DIFF
--- a/internal/check/definition.go
+++ b/internal/check/definition.go
@@ -79,6 +79,9 @@ var defaultRules = map[string]map[string]interface{}{
 		"swap":       map[string]string{},
 		"vocab":      false,
 		"path":       "internal",
+		"action": core.Action{
+			Name: "replace",
+		},
 	},
 	"Repetition": {
 		"extends":    "repetition",


### PR DESCRIPTION
This is useful for ensuring that Vocab terms get populated as quick fix/code action suggestions by the Vale Language Server.