### PR TITLE
Fix handling of xslt path and possible args pollution for xslt calls

### DIFF
--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -114,7 +114,7 @@ var syntaxOpts = map[string]func(string, *ini.Section, *Config) error{
 	},
 	"Transform": func(label string, sec *ini.Section, cfg *Config) error { //nolint:unparam
 		candidate := sec.Key("Transform").String()
-		cfg.Stylesheets[label] = system.DeterminePath(cfg.Flags.Path, candidate)
+       cfg.Stylesheets[label] = system.DeterminePath(cfg.ConfigFile(), candidate)
 		return nil
 
 	},

--- a/internal/core/ini_test.go
+++ b/internal/core/ini_test.go
@@ -114,3 +114,30 @@ CommentDelimiters = "{/*"
 		})
 	}
 }
+
+func Test_processConfig_transform(t *testing.T) {
+   body := `[*.xml]
+Transform = transform.xsl
+`
+   uCfg, err := shadowLoad([]byte(body))
+   if err != nil {
+       t.Fatal(err)
+   }
+
+   conf, err := NewConfig(&CLIFlags{})
+   if err != nil {
+       t.Fatal(err)
+   }
+   conf.AddConfigFile("C:\\Source\\project\\.vale.ini")
+
+   _, err = processConfig(uCfg, conf, false)
+   if err != nil {
+       t.Fatal(err)
+   }
+
+   actual := conf.Stylesheets["*.xml"]
+   expected := "C:\\Source\\project\\transform.xsl"
+   if actual != expected {
+       t.Errorf("expected %v, but got %v", expected, actual)
+   }
+}

--- a/internal/lint/xml.go
+++ b/internal/lint/xml.go
@@ -33,9 +33,10 @@ func (l Linter) lintXML(file *core.File) error {
 			errors.New("no XSLT transform provided"))
 	}
 
-	xsltArgs = append(xsltArgs, []string{file.Transform, "-"}...)
+    args := append([]string{}, xsltArgs...)
+    args = append(args, []string{file.Transform, "-"}...)
 
-	cmd := exec.Command(xsltproc, xsltArgs...)
+    cmd := exec.Command(xsltproc, args...)
 	cmd.Stdin = strings.NewReader(file.Content)
 	cmd.Stdout = &out
 	cmd.Stderr = &eut

--- a/internal/lint/xml_test.go
+++ b/internal/lint/xml_test.go
@@ -1,0 +1,25 @@
+package lint
+
+import (
+   "testing"
+)
+
+func TestXSLTArgsNotPolluted(t *testing.T) {
+   // We want to test that xsltArgs in xml.go is not mutated.
+   initialLen := len(xsltArgs)
+
+   // Simulate what lintXML does multiple times
+   for i := 0; i < 3; i++ {
+       args := append([]string{}, xsltArgs...)
+       args = append(args, []string{"transform.xsl", "-"}...)
+
+       if len(xsltArgs) != initialLen {
+           t.Fatalf("xsltArgs was modified! original: %d, current: %d", initialLen, len(xsltArgs))
+       }
+
+       expectedArgsLen := initialLen + 2
+       if len(args) != expectedArgsLen {
+           t.Errorf("local args have wrong length: %d, expected %d", len(args), expectedArgsLen)
+       }
+   }
+}

--- a/internal/system/path_test.go
+++ b/internal/system/path_test.go
@@ -1,0 +1,40 @@
+package system
+
+import (
+   "path/filepath"
+   "testing"
+)
+
+func TestDeterminePath(t *testing.T) {
+   tests := []struct {
+       configPath string
+       keyPath    string
+       expected   string
+   }{
+       {
+           configPath: "C:\\Source\\project\\.vale.ini",
+           keyPath:    "transform.xsl",
+           expected:   "C:\\Source\\project\\transform.xsl",
+       },
+       {
+           configPath: "C:\\Source\\project\\.vale.ini",
+           keyPath:    "styles/transform.xsl",
+           expected:   "C:\\Source\\project\\styles\\transform.xsl",
+       },
+       {
+           configPath: "C:\\Source\\project\\.vale.ini",
+           keyPath:    "C:\\Other\\transform.xsl",
+           expected:   "C:\\Other\\transform.xsl",
+       },
+   }
+
+   for _, tt := range tests {
+       actual := DeterminePath(tt.configPath, tt.keyPath)
+       // Clean the paths to ensure separators match for comparison
+       actual = filepath.Clean(actual)
+       expected := filepath.Clean(tt.expected)
+       if actual != expected {
+           t.Errorf("DeterminePath(%q, %q) = %q; want %q", tt.configPath, tt.keyPath, actual, expected)
+       }
+   }
+}


### PR DESCRIPTION
This fixes the handling of the path to xslt files along with another bug that I found along the way where vale would incorrectly compose command line arguments for xslt.