### PR TITLE
feat: add ignore field to View scopes for rule filtering

### DIFF
--- a/internal/core/view.go
+++ b/internal/core/view.go
@@ -19,9 +19,10 @@ var viewEngines = []string{"tree-sitter", "dasel"}
 
 // A Scope is a single query that we want to run against a document.
 type Scope struct {
-	Name string `yaml:"name"`
-	Expr string `yaml:"expr"`
-	Type string `yaml:"type"`
+	Name   string   `yaml:"name"`
+	Expr   string   `yaml:"expr"`
+	Type   string   `yaml:"type"`
+	Ignore []string `yaml:"ignore"` // rules to skip for this scope
 }
 
 // A View is a named, virtual representation of a subset of a file's
@@ -43,6 +44,7 @@ type ScopedValues struct {
 	Scope  string
 	Format string
 	Values []string
+	Ignore []string // rules to skip for this scope
 }
 
 // NewView creates a new blueprint from the given path.
@@ -95,6 +97,7 @@ func (b *View) Apply(f *File) ([]ScopedValues, error) {
 			Scope:  s.Name,
 			Values: values,
 			Format: s.Type,
+			Ignore: s.Ignore,
 		})
 	}
 

--- a/internal/lint/data.go
+++ b/internal/lint/data.go
@@ -39,6 +39,7 @@ func (l *Linter) lintScopedValues(f *core.File, values []core.ScopedValues) erro
 
 	for _, match := range values {
 		l.SetMetaScope(match.Scope)
+		l.SetScopeIgnore(match.Ignore)
 
 		seen := make(map[string]int)
 		for _, v := range match.Values {
@@ -74,6 +75,9 @@ func (l *Linter) lintScopedValues(f *core.File, values []core.ScopedValues) erro
 			last = size
 		}
 	}
+
+	// Reset scope-specific ignores to avoid affecting other linting paths.
+	l.SetScopeIgnore(nil)
 
 	return err
 }

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -18,12 +18,13 @@ import (
 
 // A Linter lints a File.
 type Linter struct {
-	Manager   *check.Manager
-	glob      *glob.Glob
-	client    *http.Client
-	HasDir    bool
-	nonGlobal bool
-	metaScope string
+	Manager     *check.Manager
+	glob        *glob.Glob
+	client      *http.Client
+	HasDir      bool
+	nonGlobal   bool
+	metaScope   string
+	scopeIgnore []string // rules to skip for the current scope
 }
 
 type lintResult struct {
@@ -78,6 +79,21 @@ func (l *Linter) SetMetaScope(scope string) {
 	} else {
 		l.metaScope = ""
 	}
+}
+
+// SetScopeIgnore sets the list of rules to ignore for the current scope.
+func (l *Linter) SetScopeIgnore(ignore []string) {
+	l.scopeIgnore = ignore
+}
+
+// isScopeIgnored checks if a rule should be ignored for the current scope.
+func (l *Linter) isScopeIgnored(name string) bool {
+	for _, ignored := range l.scopeIgnore {
+		if ignored == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Lint src according to its format.
@@ -301,6 +317,11 @@ func (l *Linter) shouldRun(name string, f *core.File, chk check.Rule, blk nlp.Bl
 		// See #129.
 		list := strings.Split(name, ".")
 		name = strings.Join([]string{list[0], list[1]}, ".")
+	}
+
+	// Has the check been ignored for the current scope (e.g., YAML key)?
+	if l.isScopeIgnored(name) {
+		return false
 	}
 
 	chkScope := check.NewScope(details.Scope)

--- a/testdata/features/views.feature
+++ b/testdata/features/views.feature
@@ -29,6 +29,8 @@ Feature: Views
             github-workflow.json:494:264:Vale.Spelling:Did you really mean 'prereleased'?
             github-workflow.json:568:83:Vale.Spelling:Did you really mean 'job_id'?
             github-workflow.json:652:83:Vale.Spelling:Did you really mean 'job_id'?
+            ignore.yml:3:24:Vale.Spelling:Did you really mean 'tset'?
+            ignore.yml:3:48:Vale.Spelling:Did you really mean 'speling'?
             test.java:13:38:vale.Annotations:'XXX' left in text
             test.py:1:3:vale.Annotations:'FIXME' left in text
             test.py:11:3:vale.Annotations:'XXX' left in text

--- a/testdata/fixtures/views/.vale.ini
+++ b/testdata/fixtures/views/.vale.ini
@@ -38,3 +38,8 @@ View = NewLine
 BasedOnStyles = Vale, Scopes
 
 View = Ansible
+
+[ignore.yml]
+BasedOnStyles = Vale
+
+View = Ignore

--- a/testdata/fixtures/views/ignore.yml
+++ b/testdata/fixtures/views/ignore.yml
@@ -1,0 +1,3 @@
+name: tset-resurce
+kind: DeplymentConfig
+description: This is a tset description with a speling error.

--- a/testdata/styles/config/views/Ignore.yml
+++ b/testdata/styles/config/views/Ignore.yml
@@ -1,0 +1,18 @@
+engine: dasel
+scopes:
+  # Extract 'name' field - ignore spelling errors
+  - name: metadata
+    expr: name
+    ignore:
+      - Vale.Spelling
+
+  # Extract 'kind' field - ignore spelling errors
+  - name: metadata
+    expr: kind
+    ignore:
+      - Vale.Spelling
+
+  # Extract 'description' field - all rules apply
+  - name: content
+    expr: description
+    type: md


### PR DESCRIPTION
Allow specifying rules to skip when linting specific YAML keys in Views. This enables ignoring certain rules (e.g., spelling) for metadata fields while still applying them to content fields like descriptions.

Example usage in a View file:
```
  scopes:
    - name: metadata 
      expr: name 
      ignore: 
        - Vale.Spelling
```