### PR TITLE
feat(lint): apply defaultIgnoreDirectories to nested directories

### DIFF
--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -47,6 +47,10 @@ func WhitespaceToSpace(msg string) string {
 // ShouldIgnoreDirectory will check if directory should be ignored
 func ShouldIgnoreDirectory(directoryPath string) bool {
 	directoryName := filepath.Base(directoryPath)
+	// if a current dir is detected e.g with directoryPath being an empty string always process
+	if directoryName == "." {
+		return false
+	}
 	for _, directory := range defaultIgnoreDirectories {
 		if directory == directoryName {
 			return true

--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode"
@@ -44,7 +45,8 @@ func WhitespaceToSpace(msg string) string {
 }
 
 // ShouldIgnoreDirectory will check if directory should be ignored
-func ShouldIgnoreDirectory(directoryName string) bool {
+func ShouldIgnoreDirectory(directoryPath string) bool {
+	directoryName := filepath.Base(directoryPath)
 	for _, directory := range defaultIgnoreDirectories {
 		if directory == directoryName {
 			return true

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -95,6 +95,11 @@ func TestShouldIgnoreDirectory(t *testing.T) {
 		path     string
 		expected bool
 	}{
+		{
+			name:     "empty directory name",
+			path:     "",
+			expected: false,
+		},
 		// Direct directory names
 		{
 			name:     "direct node_modules",

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -88,3 +88,74 @@ func TestNormalizePath(t *testing.T) {
 		t.Errorf("expected = %v, got = %v", expectedOutput, result)
 	}
 }
+
+func TestShouldIgnoreDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		// Direct directory names
+		{
+			name:     "direct node_modules",
+			path:     "node_modules",
+			expected: true,
+		},
+		{
+			name:     "direct .git",
+			path:     ".git",
+			expected: true,
+		},
+		// Nested paths with ignored directories
+		{
+			name:     "nested node_modules",
+			path:     "plugins/foo/node_modules",
+			expected: true,
+		},
+		{
+			name:     "nested .git in worktree",
+			path:     "worktree-a/.git",
+			expected: true,
+		},
+		{
+			name:     "deeply nested node_modules",
+			path:     "project/src/components/node_modules",
+			expected: true,
+		},
+		{
+			name:     "node_modules in path with backslashes",
+			path:     filepath.Join("project", "src", "node_modules"),
+			expected: true,
+		},
+		// Non-ignored directories
+		{
+			name:     "regular directory",
+			path:     "src",
+			expected: false,
+		},
+		{
+			name:     "nested regular directory",
+			path:     "plugins/foo",
+			expected: false,
+		},
+		{
+			name:     "directory containing node_modules in name",
+			path:     "my_node_modules_backup",
+			expected: false,
+		},
+		{
+			name:     "directory containing .git in name",
+			path:     "my.github",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShouldIgnoreDirectory(tt.path)
+			if result != tt.expected {
+				t.Errorf("ShouldIgnoreDirectory(%q) = %v, expected %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Context

Currently vale will still lint directories like `node_modules` or `.git` folders, if the are not at the root directory. 

Example cases could be: 
- JS monorepo `packages/foo/node_modules` 
- Git Worktree setup `worktree-a/.git`

### Implementation

This PR changes ignore behaviour for `defaultIgnoreDirectories` from being the full path to being the name of lowest directory name.