### PR TITLE
chore: update go to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/errata-ai/vale/v3
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
This PR is to update to Go 1.25.7 in order to remediate a few vulnerabilities found in the current version.