### PR TITLE
fix: create configured StylesPath during sync (#1105)

### DIFF
--- a/cmd/vale/sync.go
+++ b/cmd/vale/sync.go
@@ -17,8 +17,8 @@ func initPath(cfg *core.Config) error {
 	stylesPath := cfg.StylesPath()
 
 	if !system.IsDir(stylesPath) {
-		if err := os.MkdirAll(cfg.StylesPath(), os.ModePerm); err != nil {
-			e := fmt.Errorf("unable to initialize StylesPath (value = '%s')", cfg.StylesPath())
+		if err := os.MkdirAll(stylesPath, os.ModePerm); err != nil {
+			e := fmt.Errorf("unable to initialize StylesPath (value = '%s')", stylesPath)
 			return core.NewE100("initPath", e)
 		}
 	}

--- a/cmd/vale/sync_test.go
+++ b/cmd/vale/sync_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/errata-ai/vale/v3/internal/core"
+	"github.com/errata-ai/vale/v3/internal/system"
+)
+
+func setupLocalSyncTestPackage(t *testing.T, root string) (string, string) {
+	t.Helper()
+
+	stylesPath := filepath.Join(root, "missing-styles")
+	cfgPath := filepath.Join(root, ".vale.ini")
+	pkgRoot := filepath.Join(root, "local-package")
+	pkgStyles := filepath.Join(pkgRoot, "styles", "TestStyle")
+
+	if err := os.MkdirAll(pkgStyles, os.ModePerm); err != nil {
+		t.Fatalf("Failed to create local package styles directory %q: %v", pkgStyles, err)
+	}
+
+	rulePath := filepath.Join(pkgStyles, "Rule.yml")
+	if err := os.WriteFile(rulePath, []byte("extends: existence\nmessage: test\nlevel: warning\n"), 0o644); err != nil {
+		t.Fatalf("Failed to write local package rule file %q: %v", rulePath, err)
+	}
+
+	body := []byte("StylesPath = missing-styles\nPackages = " + pkgRoot + "\n")
+	if err := os.WriteFile(cfgPath, body, 0o644); err != nil {
+		t.Fatalf("Failed to write test config file %q: %v", cfgPath, err)
+	}
+
+	return stylesPath, cfgPath
+}
+
+func TestSyncCreatesConfiguredMissingStylesPath(t *testing.T) {
+	root := t.TempDir()
+	stylesPath, cfgPath := setupLocalSyncTestPackage(t, root)
+
+	if system.IsDir(stylesPath) {
+		t.Fatalf("Expected StylesPath to be missing before sync: %s", stylesPath)
+	}
+
+	err := sync(nil, &core.CLIFlags{
+		Path:         cfgPath,
+		IgnoreGlobal: true,
+	})
+	if err != nil {
+		t.Fatalf("Command 'sync' failed while creating configured StylesPath %q from config %q: %v", stylesPath, cfgPath, err)
+	}
+
+	if !system.IsDir(stylesPath) {
+		t.Fatalf("Expected sync to create configured StylesPath: %s", stylesPath)
+	}
+}
+
+func TestSyncInstallsPackageIntoConfiguredStylesPath(t *testing.T) {
+	root := t.TempDir()
+	stylesPath, cfgPath := setupLocalSyncTestPackage(t, root)
+
+	err := sync(nil, &core.CLIFlags{
+		Path:         cfgPath,
+		IgnoreGlobal: true,
+	})
+	if err != nil {
+		t.Fatalf("Command 'sync' failed while installing local package into configured StylesPath %q: %v", stylesPath, err)
+	}
+
+	installedRule := filepath.Join(stylesPath, "TestStyle", "Rule.yml")
+	if !system.FileExists(installedRule) {
+		t.Fatalf("Expected package asset to be installed into configured StylesPath: %s", installedRule)
+	}
+}
+
+func TestSyncDoesNotInstallPackageIntoGlobalStylesPath(t *testing.T) {
+	root := t.TempDir()
+	globalStylesPath := filepath.Join(root, "global-styles")
+	stylesPath, cfgPath := setupLocalSyncTestPackage(t, root)
+
+	if err := os.MkdirAll(globalStylesPath, os.ModePerm); err != nil {
+		t.Fatalf("Failed to create global StylesPath %q: %v", globalStylesPath, err)
+	}
+	t.Setenv("VALE_STYLES_PATH", globalStylesPath)
+
+	err := sync(nil, &core.CLIFlags{
+		Path: cfgPath,
+	})
+	if err != nil {
+		t.Fatalf("Command 'sync' failed with configured StylesPath %q and global StylesPath %q: %v", stylesPath, globalStylesPath, err)
+	}
+
+	installedRule := filepath.Join(stylesPath, "TestStyle", "Rule.yml")
+	if !system.FileExists(installedRule) {
+		t.Fatalf("Expected package asset to be installed into configured StylesPath: %s", installedRule)
+	}
+
+	wrongGlobalRule := filepath.Join(globalStylesPath, "TestStyle", "Rule.yml")
+	if system.FileExists(wrongGlobalRule) {
+		t.Fatalf("Expected package asset not to be installed into global StylesPath: %s", wrongGlobalRule)
+	}
+}
+
+func TestSyncDoesNotInstallPackageIntoConfigRoot(t *testing.T) {
+	root := t.TempDir()
+	_, cfgPath := setupLocalSyncTestPackage(t, root)
+
+	err := sync(nil, &core.CLIFlags{
+		Path:         cfgPath,
+		IgnoreGlobal: true,
+	})
+	if err != nil {
+		t.Fatalf("Command 'sync' failed while checking that package is not installed into config root %q: %v", root, err)
+	}
+
+	wrongConfigRootRule := filepath.Join(root, "TestStyle", "Rule.yml")
+	if system.FileExists(wrongConfigRootRule) {
+		t.Fatalf("Expected package asset not to be installed into config root: %s", wrongConfigRootRule)
+	}
+}

--- a/internal/core/ini.go
+++ b/internal/core/ini.go
@@ -168,13 +168,14 @@ var coreOpts = map[string]func(*ini.Section, *Config) error{
 	"StylesPath": func(sec *ini.Section, cfg *Config) error {
 		paths := sec.Key("StylesPath").ValueWithShadows()
 		for _, path := range paths {
+			cfg.AddStylesPath(path)
+
 			if !system.FileExists(path) {
 				return NewE201FromTarget(
 					fmt.Sprintf("The path '%s' does not exist.", path),
 					path,
 					cfg.Flags.Path)
 			}
-			cfg.AddStylesPath(path)
 		}
 		return nil
 	},


### PR DESCRIPTION
Ensure that the sync command keeps the configured StylesPath even when the directory does not exist yet. This lets sync create the missing directory instead of falling back to an existing global styles directory.

Add sync tests covering creation of the configured StylesPath, installation into that path, and negative checks for global StylesPath and config root installation.

Fixes #1105