### PR TITLE
fix(adoc): resolve empty-text cross-references corrupting walker context

### DIFF
--- a/internal/lint/adoc.go
+++ b/internal/lint/adoc.go
@@ -25,6 +25,8 @@ var adocSanitizer = strings.NewReplacer(
 // Convert listing blocks of the form `[source,.+]` to `[source]`
 var reSource = regexp.MustCompile(`\[source,.+\]`)
 var reComment = regexp.MustCompile(`// .+`)
+var reXref = regexp.MustCompile(`xref:([^\[]+)\[\]`)
+var reShortXref = regexp.MustCompile(`<<([^>,]+)>>`)
 
 var adocArgs = []string{
 	"-s",
@@ -63,6 +65,9 @@ func (l *Linter) lintADoc(f *core.File) error {
 		return err
 	}
 	s = adocSanitizer.Replace(s)
+
+	s = reXref.ReplaceAllString(s, "xref:$1[$1]")
+	s = reShortXref.ReplaceAllString(s, "<<$1,$1>>")
 
 	html, err = callAdoc(s, exe, l.Manager.Config.Asciidoctor)
 	if err != nil {


### PR DESCRIPTION
## Description
This PR fixes a silent false-negative bug where rules carrying `scope: heading` stop matching section titles in an AsciiDoc file if that file combines explicit block anchors with `xref:` inline macros (having empty link text).

Fixes #1109

### Root Cause
1. **Dynamic Target Resolution**: During HTML generation, Asciidoctor resolves empty-text cross-references (like `xref:id[]` or `<<id>>`) using the target heading's title.
2. **Missing Source Text**: Since the resolved text is not written in the raw source paragraph containing the reference, Vale's walker fails to locate the exact phrase inside the paragraph block.
3. **Word-Masking Fallback**: As a fallback, Vale starts masking the individual words (`"first"`, `"heading"`, `"lowercase"`) anywhere it can find them in the remaining document context.
4. **Context Corruption**: This matches and masks the words inside subsequent headings (e.g., `"second heading lowercase"` becomes `"second @@@@@@@ @@@@@@@@@"`).
5. **Silent Drop**: When Vale later processes these headings, they fail to match the corrupted context, leading to location lookup failures and the alert being silently discarded.

## Proposed Changes
We intercept the AsciiDoc content inside `lintADoc` in `internal/lint/adoc.go` before it is passed to Asciidoctor, and rewrite empty-text references:
- `xref:target[]` -> `xref:target[target]`
- `<<target>>` -> `<<target,target>>`

This ensures that the text rendered in the HTML tag is the literal target identifier (e.g. `#intro` or `intro`), which is present in the raw source code of the paragraph. Vale's walker successfully matches and masks it within the paragraph block, leaving subsequent headings untouched.

## How to Test and Verify

1. Run Vale with a heading-scoped rule against this sample AsciiDoc file (`repro.adoc`):
   ```asciidoc
   = Document

   [[intro]]
   == first heading lowercase

   This paragraph links to xref:#intro[].

   [[middle]]
   == second heading lowercase

   This paragraph links to xref:#intro[].

   [[final]]
   == third heading lowercase

   This paragraph links to xref:#intro[].
