### PR TITLE
docs: document -buildvcs=false workaround for pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@
 
 See the [documentation](https://vale.sh) for more information.
 
+## :hook: pre-commit
+
+Vale's [pre-commit](https://pre-commit.com) hook builds Vale from source with `go install`. In isolated environments where Go can't read the checkout's VCS metadata&mdash;dev containers, for instance, where Git may flag the directory as having [dubious ownership](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory)&mdash;the build fails with:
+
+```
+error obtaining VCS status: exit status 128
+```
+
+Disable VCS stamping to work around it:
+
+```bash
+GOFLAGS=-buildvcs=false pre-commit run --all-files
+```
+
 ## :mag: At a Glance: Vale vs. `<...>`
 
 > **NOTE**: While all of the options listed below are open-source (CLI-based) linters for prose, their implementations and features vary significantly. And so, the "best" option will depends on your specific needs and preferences.


### PR DESCRIPTION
I ran into this recently setting Vale up as a pre-commit hook inside a dev container and it took me a while to work out what was happening. The `language: golang` hook runs `go install ./...` to build Vale, and since Go 1.18 that build stamps VCS metadata by shelling out to git — in a dev container git often flags the checkout as dubious ownership and exits 128, so the whole install fails with `error obtaining VCS status: exit status 128` before Vale is ever built. That's what #926 reports.

As far as I can tell pre-commit doesn't give the hook repo any way to pass build flags into that `go install`, but it does inherit the caller's environment, so `GOFLAGS=-buildvcs=false pre-commit run --all-files` clears it (@ViggoC noted the same in the thread). I didn't want to change the hook mechanism over an environment quirk, so this is just a short README note pointing people at the workaround.

I'm not sure the README is the ideal home since everything else there defers to vale.sh — happy to move it into the docs instead if you'd rather.

Closes #926