### PR TITLE
fix: strip tab indentation from block comments

### DIFF
--- a/internal/lint/code/query.go
+++ b/internal/lint/code/query.go
@@ -13,10 +13,16 @@ type QueryEngine struct {
 	cutset string
 }
 
+// defaultCutset is the indentation a comment is dedented by when its language
+// doesn't name its own. Tabs belong here alongside spaces: a block comment
+// indented with tabs that keeps them reads as an indented code block in
+// Markdown, so its body is never linted -- see #1130.
+const defaultCutset = " \t"
+
 func NewQueryEngine(tree *sitter.Tree, lang *Language) *QueryEngine {
 	cutset := lang.Cutset
 	if cutset == "" {
-		cutset = " "
+		cutset = defaultCutset
 	}
 
 	return &QueryEngine{

--- a/testdata/e2e/fragments.yaml
+++ b/testdata/e2e/fragments.yaml
@@ -54,3 +54,44 @@ cases:
       test2.rs:165:26:Vale.Spelling:Did you really mean 'argumet'?
       test2.rs:409:38:Vale.Spelling:Did you really mean 'RGArg'?
       test2.rs:2860:34:Vale.Spelling:Did you really mean 'conlicts'?
+
+  - name: tab-indented-block
+    about: |
+      #1130: only spaces were stripped when dedenting a block comment, so one
+      indented with tabs stayed indented and Markdown read its body as a code
+      block.
+    files:
+      .vale.ini: |
+        StylesPath = ../../styles/
+        MinAlertLevel = suggestion
+
+        [formats]
+        ts = md
+
+        [*.ts]
+        BasedOnStyles = Vale
+      test.ts: |
+        /**
+         * Top-level. Reads a Recrod.
+         */
+        function x() {}
+
+        interface A {
+        	/**
+        	 * Indented with tabs. Reads a Recrod.
+        	 */
+        	x: () => {}
+        }
+
+        interface B {
+            /**
+             * Indented with spaces. Reads a Recrod.
+             */
+            x: () => {}
+        }
+    args: test.ts
+    exit: 1
+    want: |
+      test.ts:2:23:Vale.Spelling:Did you really mean 'Recrod'?
+      test.ts:8:33:Vale.Spelling:Did you really mean 'Recrod'?
+      test.ts:15:38:Vale.Spelling:Did you really mean 'Recrod'?


### PR DESCRIPTION
Fixes #1130.

### Root cause

`NewQueryEngine` in `internal/lint/code/query.go` falls back to a cutset of `" "` when a language doesn't declare one, and no language does. That cutset is what `commonIndent`/`stripIndent` use to remove a block comment's base indentation before the body is handed to the associated markup parser. A comment indented with tabs therefore kept its tabs, and Markdown read the body as an indented code block, so nothing inside it was linted. Space-indented comments were dedented correctly, which is why the bug only shows up with tabs.

### Fix

Default the cutset to `" \t"`. The dedent is otherwise unchanged: relative indentation is still preserved, and `Strip` still records what came off each line so alert columns map back to the source.

### Before / after

With the config and file from the issue (`Recrod` in three block comments, the second tab-indented):

```
# before
test.ts:2:23:Vale.Spelling:Did you really mean 'Recrod'?
test.ts:15:39:Vale.Spelling:Did you really mean 'Recrod'?

# after
test.ts:2:23:Vale.Spelling:Did you really mean 'Recrod'?
test.ts:8:23:Vale.Spelling:Did you really mean 'Recrod'?
test.ts:15:39:Vale.Spelling:Did you really mean 'Recrod'?
```

### Tests

Added `fragments/tab-indented-block` to `testdata/e2e/fragments.yaml`, which covers all three comments and fails on `v3` (the tab-indented alert is missing). `go test ./...` passes; `golangci-lint run` reports no issues.