### PR TITLE
Don't lint a shebang as a comment

### DIFF
--- a/internal/lint/code/comments.go
+++ b/internal/lint/code/comments.go
@@ -149,5 +149,26 @@ func GetComments(source []byte, lang *Language) ([]Comment, error) {
 		})
 	}
 
-	return coalesce(comments), nil
+	return coalesce(dropShebang(comments)), nil
+}
+
+// dropShebang removes a leading `#!` line.
+//
+// A shebang names the interpreter a script runs under. Languages that use `#`
+// for comments give tree-sitter no way to tell the two apart, so it arrives
+// here as a comment and is linted as prose -- a path like `/usr/bin/env` then
+// draws alerts about words the author never wrote. See #631.
+//
+// Only the very first line of the file qualifies, which is also all the kernel
+// accepts, so a `#!` written anywhere else stays a comment.
+func dropShebang(comments []Comment) []Comment {
+	for i, c := range comments {
+		if c.Line != 1 || c.Offset != 0 {
+			continue
+		} else if !strings.HasPrefix(c.Source, "#!") {
+			continue
+		}
+		return append(comments[:i:i], comments[i+1:]...)
+	}
+	return comments
 }

--- a/testdata/e2e/lint.yaml
+++ b/testdata/e2e/lint.yaml
@@ -148,6 +148,30 @@ cases:
       test.py:35:8:vale.Annotations:'NOTE' left in text
       test.py:37:5:vale.Annotations:'TODO' left in text
 
+  - name: python/shebang
+    about: "#631 -- a shebang names an interpreter, so it isn't a comment"
+    files:
+      .vale.ini: |
+        StylesPath = styles
+        MinAlertLevel = suggestion
+
+        [*.py]
+        BasedOnStyles = Test
+      styles/Test/Env.yml: |
+        extends: existence
+        message: "Use 'environment' rather than 'env'."
+        level: error
+        tokens:
+          - env
+      test.py: |
+        #!/usr/bin/env python3
+        # Read the env before starting.
+        print("hello")
+    args: test.py
+    exit: 1
+    want: |
+      test.py:2:12:Test.Env:Use 'environment' rather than 'env'.
+
   - name: cpp
     args: test.cc
     exit: 0


### PR DESCRIPTION
Fixes #631.

Tree-sitter reports the `#!` line of a script as a comment, because in Python, Ruby and Julia that is exactly what it looks like — the grammar has no separate node for it. Vale then lints the interpreter path as prose:

```console
$ cat test.py
#!/usr/bin/env python3
# Read the env before starting.
print("hello")

$ vale test.py
 test.py:1:12:Test.Env:Use 'environment' rather than 'env'.
 test.py:2:12:Test.Env:Use 'environment' rather than 'env'.
```

The first alert is against text the author didn't write and can't change; `env` is part of the path that makes the script run.

`GetComments` now drops a comment that starts at the first byte of the file and begins with `#!`. That is also all the kernel accepts as a shebang, so a `#!` written anywhere else — including the second line, or after code — stays a comment. Languages that don't use `#` never match the prefix, so nothing else moves.

The filter runs before `coalesce`, so a real comment on the line below a shebang is still linted on its own rather than disappearing with it — that's what the second alert above pins down.

The regression case is `lint/python/shebang` in `testdata/e2e/lint.yaml`; it brings its own project so the rule that fires is visible in one place. It fails on current `v3` with the extra `test.py:1:12` line and passes with the change. The whole e2e suite is green (169 scenarios), as are the unit tests, `gofmt` and `go vet`.

One caveat: I couldn't run `golangci-lint` locally — v2.5 and v2.6 both panic with `file requires newer Go version go1.26 (application built with go1.25)` against my toolchain, which is a toolchain mismatch on my side rather than anything in the diff.

AI-assisted (LLM used for drafting); the runs above are mine.
