### PR TITLE
feat: lint Groovy comments, including in a Jenkinsfile

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -55,10 +55,11 @@ var FormatByExtension = map[string][]string{
 	`\.(?:adoc|asciidoc|asc)$`:                 {".adoc", "markup"},
 	`\.(?:clj|cljs|cljc|cljd)$`:                {".clj", "code"},
 	`\.(?:cpp|cc|c|cp|cxx|c\+\+|h|hpp|h\+\+)$`: {".cpp", "code"},
-	`\.(?:css)$`:                             {".css", "code"},
-	`\.(?:cs|csx)$`:                          {".c", "code"},
-	`\.(?:dita)$`:                            {".dita", "markup"},
-	`\.(?:go)$`:                              {".go", "code"},
+	`\.(?:css)$`:    {".css", "code"},
+	`\.(?:cs|csx)$`: {".c", "code"},
+	`\.(?:dita)$`:   {".dita", "markup"},
+	`\.(?:go)$`:     {".go", "code"},
+	`\.(?:groovy|gvy|gy|gsh|gradle|[Jj]enkinsfile)$`: {".groovy", "code"},
 	`\.(?:hs)$`:                              {".hs", "code"},
 	`\.(?:html|htm|shtml|xhtml)$`:            {".html", "markup"},
 	`\.(?:java|bsh)$`:                        {".java", "code"},
@@ -96,6 +97,12 @@ var FormatByExtension = map[string][]string{
 // list, if supported.
 func FormatFromExt(path string, mapping map[string]string) (string, string) {
 	base := strings.Trim(filepath.Ext(path), ".")
+	if base == "" {
+		// An extensionless file is known only by its name: `Jenkinsfile`,
+		// `Gemfile`, `SConstruct`. Let the name stand in for the extension, so
+		// the table above -- which already lists such names -- can match it.
+		base = filepath.Base(path)
+	}
 	kind := getFormat("." + base)
 
 	if format, found := mapping[base]; found {

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -18,6 +18,16 @@ func TestFormatFromExt(t *testing.T) {
 		".rmd":   {".md", "markup"},
 		".R":     {".r", "code"},
 		".qml":   {".qml", "code"},
+
+		".groovy": {".groovy", "code"},
+		".gradle": {".groovy", "code"},
+
+		// An extensionless file is matched by its name.
+		"Jenkinsfile":            {".groovy", "code"},
+		"ci/cd/Jenkinsfile":      {".groovy", "code"},
+		"Gemfile":                {".rb", "code"},
+		"SConstruct":             {".py", "code"},
+		"no/such/format/LICENSE": {"unknown", "unknown"},
 	}
 	m := map[string]string{}
 	for ext, format := range extToFormat {

--- a/internal/lint/code.go
+++ b/internal/lint/code.go
@@ -43,6 +43,12 @@ func (l *Linter) skipsComment(scope string) bool {
 func (l *Linter) lintCode(f *core.File) error {
 	lang, err := code.GetLanguageFromExt(f.RealExt)
 	if err != nil {
+		// The real extension names no grammar -- the file may have none at
+		// all (`Jenkinsfile`), or carry one only a `[formats]` association
+		// explains. The normed extension knows both.
+		lang, err = code.GetLanguageFromExt(f.NormedExt)
+	}
+	if err != nil {
 		// No tree-sitter grammar available for this file type.
 		return l.lintCodeOld(f)
 	}

--- a/internal/lint/code/groovy.go
+++ b/internal/lint/code/groovy.go
@@ -1,0 +1,24 @@
+package code
+
+import (
+	"regexp"
+
+	"github.com/errata-ai/vale/v3/internal/core"
+	"github.com/smacker/go-tree-sitter/groovy"
+)
+
+func Groovy() *Language {
+	return &Language{
+		Delims: regexp.MustCompile(`//|/\*\*?|\*/`),
+		Prefix: cStylePrefix,
+		Parser: groovy.GetLanguage(),
+		// The grammar has one `comment` node for both `//` and `/* */`
+		// comments; Groovydoc (`/** */`) is its own node. A shebang is a
+		// `shebang` node, so it never arrives here as a comment.
+		Queries: []core.Scope{
+			{Name: "", Expr: "(comment) @comment", Type: ""},
+			{Name: "", Expr: "(groovy_doc) @comment", Type: ""},
+		},
+		Padding: cStyle,
+	}
+}

--- a/internal/lint/code/lang.go
+++ b/internal/lint/code/lang.go
@@ -57,6 +57,8 @@ func GetLanguageFromExt(ext string) (*Language, error) {
 		return Julia(), nil
 	case ".java":
 		return Java(), nil
+	case ".groovy":
+		return Groovy(), nil
 	case ".lua":
 		return Lua(), nil
 	case ".php":

--- a/testdata/comments/in/8.groovy
+++ b/testdata/comments/in/8.groovy
@@ -1,0 +1,30 @@
+#!/usr/bin/env groovy
+// This is a line comment.
+// It spans two lines.
+
+/*
+ * This is a block comment.
+ * It also spans two lines.
+ */
+
+/**
+ * This is a Groovydoc comment.
+ *
+ * With a second paragraph.
+ */
+class Example {
+    static void main(String[] args) {
+        println('Hello World') // A trailing comment.
+    }
+}
+
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                sh 'make' /* An inline block comment. */
+            }
+        }
+    }
+}

--- a/testdata/comments/out/8.json
+++ b/testdata/comments/out/8.json
@@ -1,0 +1,37 @@
+[
+    {
+        "Text": "This is a line comment.\nIt spans two lines.\n",
+        "Source": "// This is a line comment.\n// It spans two lines.\n",
+        "Line": 2,
+        "Offset": 0,
+        "Scope": "text.comment.line"
+    },
+    {
+        "Text": "\nThis is a block comment.\nIt also spans two lines.\n\n",
+        "Source": "/*\n * This is a block comment.\n * It also spans two lines.\n */",
+        "Line": 5,
+        "Offset": 0,
+        "Scope": "text.comment.block"
+    },
+    {
+        "Text": "\nThis is a Groovydoc comment.\n\nWith a second paragraph.\n\n",
+        "Source": "/**\n * This is a Groovydoc comment.\n *\n * With a second paragraph.\n */",
+        "Line": 10,
+        "Offset": 0,
+        "Scope": "text.comment.block"
+    },
+    {
+        "Text": "A trailing comment.",
+        "Source": "// A trailing comment.",
+        "Line": 17,
+        "Offset": 31,
+        "Scope": "text.comment.line"
+    },
+    {
+        "Text": "An inline block comment. ",
+        "Source": "/* An inline block comment. */",
+        "Line": 26,
+        "Offset": 26,
+        "Scope": "text.comment.line"
+    }
+]

--- a/testdata/e2e/lint.yaml
+++ b/testdata/e2e/lint.yaml
@@ -40,6 +40,23 @@ cases:
       test.java:1:4:vale.Annotations:'XXX' left in text
       test.java:9:4:vale.Annotations:'TODO' left in text
 
+  - name: groovy
+    args: test.groovy
+    exit: 0
+    want: |
+      test.groovy:1:4:vale.Annotations:'XXX' left in text
+      test.groovy:8:4:vale.Annotations:'TODO' left in text
+      test.groovy:14:4:vale.Annotations:'NOTE' left in text
+      test.groovy:18:41:vale.Annotations:'FIXME' left in text
+
+  - name: jenkinsfile
+    about: An extensionless Jenkinsfile lints as Groovy; its shebang is skipped.
+    args: Jenkinsfile
+    exit: 0
+    want: |
+      Jenkinsfile:5:18:vale.Annotations:'XXX' left in text
+      Jenkinsfile:9:16:vale.Annotations:'TODO' left in text
+
   - name: proto
     args: test.proto
     exit: 0

--- a/testdata/fixtures/formats/Jenkinsfile
+++ b/testdata/fixtures/formats/Jenkinsfile
@@ -1,0 +1,15 @@
+#!/usr/bin/env groovy
+// The shebang above names an interpreter path and must not be linted.
+
+pipeline {
+    agent any // XXX: run anywhere
+
+    stages {
+        stage('Build') {
+            /* TODO: add a real build step. */
+            steps {
+                sh 'make'
+            }
+        }
+    }
+}

--- a/testdata/fixtures/formats/test.groovy
+++ b/testdata/fixtures/formats/test.groovy
@@ -1,0 +1,20 @@
+// XXX: This is an annotation
+// And this uses too many weasel words like obviously and very.
+
+/*
+ * This is a multi-line comment.
+ * It can span across several lines.
+ *
+ * TODO: Refactor this code to improve readability.
+ */
+
+/**
+ * Groovydoc for a class.
+ *
+ * NOTE: Groovydoc is its own node in the grammar.
+ */
+class HelloWorld {
+    static void main(String[] args) {
+        println('Hello World, XXX!') // FIXME: a trailing comment
+    }
+}


### PR DESCRIPTION
This adds Groovy to the tree-sitter-backed source formats, with `Jenkinsfile` as the motivating case.

## What changed

- **`internal/lint/code/groovy.go`** — a new `Language` using the Groovy grammar that `smacker/go-tree-sitter` already bundles (no new dependency). The grammar has a single `comment` node for both `//` and `/* */`, a separate `groovy_doc` node for `/** */`, and a `shebang` node — so `#!/usr/bin/env groovy` never reaches the linter as prose. Delimiters, `cStylePrefix` decoration handling, and padding follow `java.go`/`js.go`.
- **`internal/core/format.go`** — routes `.groovy`, `.gvy`, `.gy`, `.gsh`, `.gradle`, and `Jenkinsfile` to `.groovy`/`code`. `FormatFromExt` now falls back to the file's basename when the path has no extension. The extension table already lists such names — `Gemfile`, `Rakefile`, `SConstruct` — but nothing could match them: `filepath.Ext` returns `""` for an extensionless path. This makes those existing entries work as written, and lets `Jenkinsfile` join them.
- **`internal/lint/code.go`** — `lintCode` retries `GetLanguageFromExt` with the normed extension when the real one names no grammar. An extensionless file has no real extension to match, and a `[formats]` association onto a code format previously fell through to the deprecated comment-regexp path, which no longer lists those formats and so found no comments at all.

## Tests

- `testdata/comments/in/8.groovy` + golden: line-comment runs, block dedent, Groovydoc `*` decoration, trailing and inline comments, shebang dropped.
- `TestFormatFromExt`: `.groovy`/`.gradle`, plus extensionless `Jenkinsfile`, `Gemfile`, and `SConstruct`, and an unknown extensionless name.
- e2e `lint/groovy` and `lint/jenkinsfile` cases over new `fixtures/formats` files; the Jenkinsfile case shows the shebang is skipped and comments lint at the right positions.

`make test` passes (202 scenarios, 331 assertions; skips only suites needing uninstalled converters). `golangci-lint` reports no new issues in the touched packages.