### PR TITLE
fix(lint): treat an HTML comment as a text boundary outside inline elements

### DIFF
--- a/internal/lint/ast.go
+++ b/internal/lint/ast.go
@@ -163,6 +163,13 @@ func (l *Linter) lintHTMLTokens(f *core.File, raw []byte, offset int) error { //
 				}
 			}
 		} else if tokt == html.CommentToken {
+			// A comment, like a closed inline element, is a source-faithful
+			// boundary: trust the next text's own whitespace (#882). Inside a
+			// still-open inline element the opening tag remains the boundary,
+			// so leave the state alone and keep its padding (#1052).
+			if !inline {
+				closedInline = true
+			}
 			f.UpdateComments(txt)
 			walker.update(txt, tokt)
 		} else if tokt == html.TextToken {

--- a/testdata/e2e/comments.yaml
+++ b/testdata/e2e/comments.yaml
@@ -100,3 +100,10 @@ cases:
     exit: 0
     want: |
       issue1001.md:5:28:demo.Ending-Preposition:Don't end a sentence with 'of.'
+
+  - name: inline-comment-spacing
+    about: "#882 -- text after a comment keeps its own leading space instead of
+      fusing with the text before it"
+    args: issue882.md
+    exit: 0
+    want: ""

--- a/testdata/e2e/comments.yaml
+++ b/testdata/e2e/comments.yaml
@@ -103,7 +103,9 @@ cases:
 
   - name: inline-comment-spacing
     about: "#882 -- text after a comment keeps its own leading space instead of
-      fusing with the text before it"
+      fusing with the text before it; inside a still-open inline element the
+      opening tag stays the boundary, so `sona` isn't fused into `sonata`"
     args: issue882.md
-    exit: 0
-    want: ""
+    exit: 1
+    want: |
+      issue882.md:4:3:Vale.Spelling:Did you really mean 'sona'?

--- a/testdata/fixtures/comments/.vale.ini
+++ b/testdata/fixtures/comments/.vale.ini
@@ -12,3 +12,6 @@ demo.SentenceCaseAny = NO
 
 [test2.mdx]
 CommentDelimiters = {/*, */}
+
+[issue882.md]
+BasedOnStyles = Vale

--- a/testdata/fixtures/comments/issue882.md
+++ b/testdata/fixtures/comments/issue882.md
@@ -1,0 +1,4 @@
+on <!-- TODO --> a
+sonata
+
+A sona<em><!--c-->ta</em> here.


### PR DESCRIPTION
An HTML comment between two words causes a false spelling alert:

```
$ cat test.md
on <!-- TODO --> a
sonata

$ vale test.md
test.md:2:2  error  Did you really mean 'ona'?  Vale.Spelling
```

Removing the comment yields no alerts.

`lintHTMLTokens` sets `closedInline` in the `EndTagToken` branch and clears it in `StartTagToken`, but a `CommentToken` leaves it untouched. Its consumer is `clean()`, whose whitespace decision is `(closedInline && spaced) || (!closedInline && inline && !starter)`. After a comment both flags are stale-false, so neither arm fires, the following text loses its leading space, and `on` + `a` fuse into `ona`.

Setting `closedInline` on a comment only fixes the outer case: a comment right after an inline *opening* tag is not a closed boundary, and asserting one there disables the `#1052` padding. That loses real alerts and invents words — `A sona<em><!--c-->ta</em>` fuses to `sonata`, so the genuine `sona` alert disappears.

So the flag is set only when no inline element is open. Inside one, the opening tag remains the boundary and its padding is preserved.

Fixes #882

## Verification

Built before/after binaries and compared:

| input | before | after |
|---|---|---|
| `on <!-- TODO --> a` / `sonata` | `2:2 'ona'` | no alert |
| `A sona<em><!--c-->ta</em> here.` | `1:3 'sona'` | `1:3 'sona'` |
| `A sona<b><!-- c --></b>ta here.` | unchanged | unchanged |
| `in <code><!--c-->x</code> for` | unchanged | unchanged |
| `word<!--c-->s` | stays `words` | stays `words` |
| `A <!-- c --> sona` | no alert (fused to `Asona`) | `1:14 'sona'` |

The last row is a second bug the same change fixes: text after a comment at the start of a fragment was being fused to the preceding word.

`go build ./...` and `go test ./...` pass. The regression case is in `testdata/e2e/comments.yaml` alongside the existing `#1001` comment case, and it fails without the fix.

Note `lintHTMLTokens` is shared across html/md/adoc/rst/org/dita/xml, so this affects all of them; I checked the `.html` path behaves the same.
