### PR TITLE
fix(dita): report dita's own error output instead of just the exit status

### DIFF
--- a/internal/lint/dita.go
+++ b/internal/lint/dita.go
@@ -42,6 +42,11 @@ func (l *Linter) lintDITA(file *core.File) error {
 	cmd.Stderr = &out
 
 	if err = cmd.Run(); err != nil {
+		// dita's own diagnostics are far more useful than the exit status,
+		// but it doesn't always write any
+		if msg := strings.TrimSpace(out.String()); msg != "" {
+			return core.NewE100(file.Path, errors.New(msg))
+		}
 		return core.NewE100(file.Path, err)
 	}
 


### PR DESCRIPTION
`lintDITA` wires the `dita` command's stderr into a buffer and then never reads it, so a failed conversion shows only the exit status:

```
E100 [a.dita] Runtime error

exit status 1
```

The actual diagnostic — DTD resolution failures, malformed maps, missing conrefs — is discarded.

This returns the captured stderr, the way `lintXML` already does at `internal/lint/xml.go:45`:

```
E100 [a.dita] Runtime error

[DOTX046E][ERROR] The DTD could not be resolved.
```

Fixes #578

## The fallback matters

Copying `lintXML` verbatim (`errors.New(eut.String())`) would regress the case where `dita` exits non-zero without writing anything — the error body would be blank, which is worse than today. So the exit status is kept as a fallback:

| dita behaviour | before | after |
|---|---|---|
| writes to stderr, exits 1 | `exit status 1` | the stderr text |
| exits 1 silently | `exit status 1` | `exit status 1` |
| succeeds | unchanged | unchanged |

Verified both failing cases with a stub `dita` on PATH.

Worth being precise about the scope: `dita` writes some diagnostics to stdout rather than stderr, and those still will not appear. Only `cmd.Stderr` is captured here, and I did not want to conflate the two streams into one buffer since that would change what the message looks like in the common case.

`go test ./internal/...` passes. The DITA e2e cases are gated behind `requires: dita` and all cover the success path, which this does not touch.
