### PR TITLE
fix(lint): apply suppression comments to relocated footnote definitions

### DIFF
--- a/internal/lint/ast.go
+++ b/internal/lint/ast.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"bytes"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -45,6 +46,13 @@ var inlineToScope = map[string]string{
 	"tt":     "code",
 }
 
+// goldmarkFootnotes names the formats goldmark converts. Its Footnote
+// extension moves every definition into a trailing `div.footnotes`, so the
+// comment state the walker reaches there is whatever the end of the document
+// left behind rather than what governed the reference. Elsewhere -- rST,
+// AsciiDoc, HTML -- that class carries no such promise. See #1078.
+var goldmarkFootnotes = []string{".md", ".mdx", ".myst", ".qmd"}
+
 var tagToScope = map[string]string{
 	"th":         "text.table.header",
 	"td":         "text.table.cell",
@@ -87,9 +95,16 @@ func (l *Linter) lintHTMLTokens(f *core.File, raw []byte, offset int) error { //
 	}
 	var open []inlineCapture
 
+	var notes footnotes
+	relocated := core.StringInSlice(f.NormedExt, goldmarkFootnotes)
+
 	walker := newWalker(f, raw, offset)
 	for {
 		tokt, tok, txt := walker.walk()
+
+		if relocated {
+			notes.enter(f, tokt, tok, txt)
+		}
 
 		walker.addCls(txt, tokt == html.StartTagToken)
 		closed := walker.canClose()
@@ -250,6 +265,9 @@ func (l *Linter) lintHTMLTokens(f *core.File, raw []byte, offset int) error { //
 		if tokt == html.EndTagToken && !core.StringInSlice(txt, inlineTags) {
 			content := buf.String()
 			if strings.TrimSpace(content) != "" {
+				if notes.depth > 0 {
+					notes.apply(f, content)
+				}
 				err := l.lintScope(f, walker, content)
 				if err != nil {
 					return err
@@ -270,6 +288,118 @@ func (l *Linter) lintHTMLTokens(f *core.File, raw []byte, offset int) error { //
 	}
 
 	return l.lintSizedScopes(f)
+}
+
+// reSourceComment finds a comment control in the source, so that a relocated
+// footnote can be given the state its own position earned rather than the one
+// the end of the document left behind.
+var reSourceComment = regexp.MustCompile(`(?s)<!--(.*?)-->`)
+
+// footnotes restores the comment state that governs a footnote definition.
+//
+// goldmark's Footnote extension moves every definition into a trailing
+// `div.footnotes`, so by the time the walker reaches one, a `= NO` ... `= YES`
+// pair enclosing it in the source has already flipped back. Inside that div we
+// rebuild the state from the definition's own line instead. See #1078.
+type footnotes struct {
+	lines []int
+	text  []string
+
+	outer map[string]bool
+	depth int
+}
+
+// index records where each comment control sits in the source, by line.
+func (s *footnotes) index(content string) {
+	for _, m := range reSourceComment.FindAllStringSubmatchIndex(content, -1) {
+		s.lines = append(s.lines, strings.Count(content[:m[0]], "\n"))
+		s.text = append(s.text, strings.TrimSpace(content[m[2]:m[3]]))
+	}
+}
+
+// enter tracks the relocated block's nesting, keeping the state to put back
+// once it closes.
+func (s *footnotes) enter(f *core.File, tokt html.TokenType, tok html.Token, txt string) {
+	if txt != "div" {
+		return
+	} else if tokt == html.EndTagToken {
+		if s.depth > 0 && s.depth-1 == 0 {
+			f.Comments = s.outer
+		}
+		s.depth = max(s.depth-1, 0)
+	} else if s.depth > 0 {
+		s.depth++
+	} else if checkClasses(getAttribute(tok, "class"), []string{"footnotes"}) {
+		s.outer, s.depth = f.Comments, 1
+		s.index(f.Content)
+	}
+}
+
+// apply gives a relocated definition the state its own place in the source
+// had, by replaying every comment control that precedes it.
+func (s *footnotes) apply(f *core.File, text string) {
+	line := s.lineOf(f.Content, text)
+	if line < 0 {
+		return
+	}
+
+	f.Comments = map[string]bool{}
+	for i, at := range s.lines {
+		if at > line {
+			break
+		}
+		f.UpdateComments(s.text[i])
+	}
+}
+
+// reFootnoteDef finds where a definition begins in the source: always its own
+// line, opening with the label it was referenced by. The label itself is
+// starred out by `prepMarkdown`, so it's matched by shape rather than by name.
+var reFootnoteDef = regexp.MustCompile(`(?m)^[ \t]*\[[^\]\n]*\]:`)
+
+// lineOf finds the source line a definition's text came from. Like `advance`,
+// it settles for the longest word: rendering rewrites a definition -- markup
+// stripped, a backref appended -- so the block itself is rarely a substring of
+// the source.
+//
+// Only the definitions are searched, not the whole document: the same word
+// commonly appears in ordinary prose too, and the first occurrence anywhere is
+// no more the definition's line than any other. A miss returns -1, leaving the
+// state alone rather than replaying to a wrong place.
+func (s *footnotes) lineOf(content, text string) int {
+	longest := ""
+	for _, w := range strings.Fields(text) {
+		if len(w) > len(longest) {
+			longest = w
+		}
+	}
+	if longest == "" {
+		return -1
+	}
+
+	for _, m := range reFootnoteDef.FindAllStringIndex(content, -1) {
+		if strings.Contains(defBody(content, m[0]), longest) {
+			return strings.Count(content[:m[0]], "\n")
+		}
+	}
+	return -1
+}
+
+// defBody returns the source of the definition beginning at `at`: its own line,
+// plus the indented lines continuing it. It stops at the first unindented line,
+// which is where the definition ends -- the next one, or the prose after it.
+func defBody(content string, at int) string {
+	body := content[at:]
+
+	end := 0
+	for _, line := range strings.SplitAfter(body, "\n") {
+		if end > 0 && strings.TrimSpace(line) != "" && !startsWithSpace(line) {
+			break
+		}
+		end += len(line)
+	}
+
+	return body[:end]
 }
 
 func (l *Linter) lintScope(f *core.File, state *walker, txt string) error {

--- a/internal/lint/ast.go
+++ b/internal/lint/ast.go
@@ -322,14 +322,17 @@ func (s *footnotes) index(content string) {
 func (s *footnotes) enter(f *core.File, tokt html.TokenType, tok html.Token, txt string) {
 	if txt != "div" {
 		return
-	} else if tokt == html.EndTagToken {
+	}
+
+	switch {
+	case tokt == html.EndTagToken:
 		if s.depth > 0 && s.depth-1 == 0 {
 			f.Comments = s.outer
 		}
 		s.depth = max(s.depth-1, 0)
-	} else if s.depth > 0 {
+	case s.depth > 0:
 		s.depth++
-	} else if checkClasses(getAttribute(tok, "class"), []string{"footnotes"}) {
+	case checkClasses(getAttribute(tok, "class"), []string{"footnotes"}):
 		s.outer, s.depth = f.Comments, 1
 		s.index(f.Content)
 	}

--- a/internal/lint/md_test.go
+++ b/internal/lint/md_test.go
@@ -1,0 +1,89 @@
+package lint
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/errata-ai/vale/v3/internal/core"
+)
+
+// TestFootnoteSuppression pins that a comment control reaches a footnote
+// definition. goldmark moves every definition into a trailing
+// `div.footnotes`, so a walk that took the toggles in the order they arrive
+// saw a `= NO` ... `= YES` pair already closed by the time the definition was
+// linted, and the suppression silently did nothing. See #1078.
+func TestFootnoteSuppression(t *testing.T) {
+	// want holds the source lines expected to carry an alert on the misspelling,
+	// so that a case with more than one occurrence says which of them survives.
+	cases := []struct {
+		name string
+		in   string
+		want []int
+	}{
+		{
+			"a definition inside the block is suppressed",
+			"Text with a footnote[^x].\n\n<!-- vale Vale.Spelling = NO -->\n\n" +
+				"[^x]: I want to talk about thingamajigg in a footnote.\n\n" +
+				"<!-- vale Vale.Spelling = YES -->\n\nMore text here.\n",
+			nil,
+		},
+		{
+			"a definition outside any block is not",
+			"Text with a footnote[^x].\n\n" +
+				"[^x]: I want to talk about thingamajigg in a footnote.\n\nMore text here.\n",
+			[]int{3},
+		},
+		{
+			"a later block does not reach back to an earlier definition",
+			"Text with a footnote[^x].\n\n" +
+				"[^x]: I want to talk about thingamajigg in a footnote.\n\n" +
+				"<!-- vale Vale.Spelling = NO -->\n\nMore text here.\n\n" +
+				"<!-- vale Vale.Spelling = YES -->\n",
+			[]int{3},
+		},
+		{
+			"an earlier mention of the same word does not place the definition",
+			"An intro mentioning thingamajigg early on, plus a footnote[^x].\n\n" +
+				"<!-- vale Vale.Spelling = NO -->\n\n" +
+				"[^x]: I want to talk about thingamajigg in a footnote.\n\n" +
+				"<!-- vale Vale.Spelling = YES -->\n\nTrailing text.\n",
+			[]int{1},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg, err := core.NewConfig(&core.CLIFlags{IgnoreGlobal: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg.MinAlertLevel = 0
+			cfg.GBaseStyles = []string{"Vale"}
+			cfg.Flags.InExt = ".md"
+
+			linter, err := NewLinter(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			files, err := linter.LintString(c.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var got []int
+			for _, f := range files {
+				for _, a := range f.Alerts {
+					if strings.Contains(a.Match, "thingamajigg") {
+						got = append(got, a.Line)
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("alerts on lines %v; want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1078.

## What's broken

Suppression comments do not suppress alerts inside footnote definitions.

```
$ cat mwe.md
Here is some text that has a footnote[^x].

<!-- vale Vale.Spelling = NO -->

[^x]: I want to talk about thingamajigg in a footnote.

<!-- vale Vale.Spelling = YES -->

Some more text here about nothing.

$ vale --output=line mwe.md
mwe.md:5:40:Vale.Spelling:Did you really mean 'thingamajigg'?
```

The same document with the footnote replaced by a plain paragraph reports nothing.

## The cause

Not what the issue reporter guessed. goldmark's Footnote extension relocates every definition into a trailing `div.footnotes`, which I confirmed by dumping the rendered HTML:

```
<!-- vale Vale.Spelling = NO -->
<!-- vale Vale.Spelling = YES -->
<p>Some more text here about nothing.</p>
<div class="footnotes" ...>
<li id="fn:1"><p>I want to talk about thingamajigg ...</p></li>
```

The toggle state is a linear walk over the token stream, so by the time the relocated text is reached, the `= YES` has already re-enabled the check. The telling detail is the converse: an unterminated `= NO` does suppress the footnote, which is only possible if position in the stream, not the footnote itself, is the variable.

## The fix

Inside that div, rebuild the state from the definition's own source line by replaying the comment controls that precede it, then restore the ambient state on the closing tag.

One deviation worth calling out: I key on the definition's source position, not the reference's. The issue's own example has the reference on line 1, outside the suppression block, with only the definition inside it. Keying on the reference leaves that example still reporting the alert. I built it that way first and confirmed it.

## MyST and qmd

The `div.footnotes` container is a goldmark promise, not a general one, so the branch is gated on `.md`, `.mdx`, `.myst` and `.qmd`. Those are exactly the four whose converters register `extension.Footnote`, so rST, AsciiDoc and HTML never enter it. MyST and qmd are included because they relocate footnotes too and had the same bug; their existing tests pass unchanged.

## Verification

`go build ./...` clean and `go test ./internal/...` passes in full.

The MWE above now reports nothing and exits 0. Deleting the suppression comments brings the alert back.

The interesting case is this one, which broke my first attempt:

```
An intro mentioning thingamajigg early on, plus a footnote[^x].

<!-- vale Vale.Spelling = NO -->

[^x]: I want to talk about thingamajigg in a footnote.
```

Resolving the definition by searching the whole document for its longest word finds line 1, so the replay stopped before the `= NO` and the definition was not suppressed. It now walks the source's definition starts and picks the one whose body contains the word. Only the line-1 alert is reported, which is correct.

Also checked: two footnotes where one is suppressed and one is not, and a definition whose longest word recurs in a later paragraph. Both behave.

One honest weakness. `f.Content` is `prepMarkdown`-processed, which stars out the label, so `[^x]:` becomes `[**]:` and the regex has to match definitions by shape rather than by `\[\^`. That means a link reference definition could in principle be selected first if it contained the same longest word. I could not construct a case where this produced a wrong suppression, since link definition labels are starred out and their URLs are not linted, but the ambiguity is there and I would rather you knew about it than found it.

This touches the same walker branch as #1001, #1052 and #1111. The change is purely additive, three touch points in the loop and a self-contained type below `lintHTMLTokens`, so it should not conflict badly.
