### PR TITLE
fix(ls-metrics): report instead of panicking when nothing lints

### DIFF
--- a/cmd/vale/command.go
+++ b/cmd/vale/command.go
@@ -236,6 +236,14 @@ func printMetrics(args []string, _ *core.CLIFlags) error {
 		return err
 	}
 
+	// `FileExists` is true for a directory, and a directory that holds no
+	// lintable file lints to nothing. Reporting that is better than printing
+	// `{}`, which already means "a file Vale read and found no metrics in".
+	if len(linted) == 0 {
+		return core.NewE100("ls-metrics", fmt.Errorf(
+			"'%s' contains no lintable files", args[0]))
+	}
+
 	computed, _ := linted[0].ComputeMetrics()
 	return printJSON(computed)
 }

--- a/testdata/e2e/metrics.yaml
+++ b/testdata/e2e/metrics.yaml
@@ -34,6 +34,21 @@ cases:
     want: |
       {}
 
+  - name: empty-directory
+    about: the argument only has to exist, and a directory does -- so one
+      whose every file is skipped (`node_modules` is ignored by default)
+      lints to nothing, and saying so beats indexing an empty result, which
+      used to panic
+    files:
+      empty/node_modules/test.md: |
+        # Title
+    args: ls-metrics empty
+    exit: 2
+    contains: |
+      E100 [ls-metrics] Runtime error
+
+      'empty' contains no lintable files
+
   - name: formula
     about: a `metric` rule reads the same counts -- the weighted total spells
       them out, so 221 means 2 H2s, 2 list items, and 1 blockquote


### PR DESCRIPTION
## What's broken

`vale ls-metrics` panics on any path that lints to zero files.

```
$ mkdir /tmp/vempty
$ vale ls-metrics /tmp/vempty
panic: runtime error: index out of range [0] with length 0
	main.printMetrics(...) cmd/vale/command.go:239
	main.main() cmd/vale/main.go:145
```

The guard above it is `system.FileExists(args[0])`, which is `os.Stat(f) == nil` and therefore true for a directory. `linter.Lint` returns an empty slice when nothing matches, and `linted[0]` is unchecked.

A single non-lintable file is fine, `vale ls-metrics pic.png` prints `{}`, which is exactly what makes this look covered. The reachable cases are an empty directory, a directory of only empty subdirectories, and a directory whose files all sit under a default-ignored path such as `node_modules` or `.git`.

## The fix

Guard the index and return an error naming the situation:

```
$ vale ls-metrics /tmp/vempty
E100 [ls-metrics] Runtime error

'/tmp/vempty' contains no lintable files
```

An error rather than `{}`, because `testdata/e2e/metrics.yaml` already pins `ls-metrics test.txt` to exit 0 with `{}` for a real file Vale read and found no metrics in. Reusing `{}` for "Vale read nothing at all" would conflate the two and hide the mistake. `core.NewE100` is what the sibling commands in `command.go` use, and `handleError` renders it and exits 2.

## Verification

An `empty-directory` case in `testdata/e2e/metrics.yaml`, run by `internal/e2e/e2e_test.go`. It uses the suite's inline `files:` mechanism, since git cannot check in an empty directory, and puts the only file under `node_modules` so the walker skips it and the lint comes back empty.

With the guard reverted the case fails with the panic above instead of the expected output. `go test ./...` passes, and `golangci-lint run ./cmd/...` reports the same single pre-existing gosec issue with and without the change.
