### PR TITLE
fix: --glob panics on a pattern gobwas/glob rejects

### DIFF
--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -12,19 +12,22 @@ import (
 type Glob struct {
 	Pattern string
 	Negated bool
+
+	// compiled is the `gobwas/glob` form of Pattern, built once by NewGlob.
+	// It's nil for a `**` pattern, which doublestar matches instead.
+	compiled glob.Glob
 }
 
 // Match returns whether or not the Glob g matches the string query.
 func (g Glob) Match(query string) bool {
 	q := filepath.ToSlash(query)
 
-	if strings.Contains(g.Pattern, "**") {
+	if g.compiled == nil {
 		matched, _ := doublestar.Match(g.Pattern, q)
 		return matched != g.Negated
 	}
 
-	p := glob.MustCompile(g.Pattern)
-	return p.Match(q) != g.Negated
+	return g.compiled.Match(q) != g.Negated
 }
 
 // MatchAny returns whether or not the Glob g matches any of the strings in
@@ -49,7 +52,18 @@ func NewGlob(pat string) (Glob, error) {
 	if err != nil {
 		return Glob{}, err
 	}
-	return Glob{Pattern: pat, Negated: negate}, nil
+
+	if strings.Contains(pat, "**") {
+		return Glob{Pattern: pat, Negated: negate}, nil
+	}
+
+	// doublestar accepts patterns gobwas/glob rejects, and Match used to
+	// compile there with MustCompile -- so `--glob='[a-]*'` panicked mid-walk.
+	compiled, err := glob.Compile(pat)
+	if err != nil {
+		return Glob{}, err
+	}
+	return Glob{Pattern: pat, Negated: negate, compiled: compiled}, nil
 }
 
 // Compile is a wrapper around NewGlobal for backwards compatibility.

--- a/internal/glob/glob_test.go
+++ b/internal/glob/glob_test.go
@@ -32,6 +32,20 @@ var globTests = []struct {
 	},
 }
 
+// Patterns doublestar accepts and gobwas/glob rejects. NewGlob has to report
+// them, since Match can't: it used to compile with MustCompile and panicked
+// partway through the walk.
+var invalidGlobs = []string{`[a-]`, `[a-b-c]`}
+
+func TestInvalidGlob(t *testing.T) {
+	for _, pat := range invalidGlobs {
+		g, err := NewGlob(pat)
+		if err == nil {
+			t.Errorf("%s: expected an error, got %+v", pat, g)
+		}
+	}
+}
+
 func TestGlob(t *testing.T) {
 	for _, tt := range globTests {
 		g, _ := NewGlob(tt.pattern)

--- a/testdata/e2e/config-flags.yaml
+++ b/testdata/e2e/config-flags.yaml
@@ -94,6 +94,14 @@ cases:
       - py
     requires: asciidoctor, dita, rst2html, xsltproc
 
+  - name: glob-invalid
+    about: "a pattern gobwas/glob rejects used to panic mid-walk"
+    dir: ../glob
+    args: "--glob=[a-]* ."
+    exit: 2
+    want: |
+      expected close range character
+
   - name: no-config-found
     dir: ../../../..
     args: .


### PR DESCRIPTION
## What's broken

`--glob` panics on a pattern that `doublestar` accepts and `gobwas/glob` does not.

```
$ vale --glob='[a-]*.md' .
panic: expected close range character

goroutine 36 [running]:
github.com/gobwas/glob.MustCompile(...)
	github.com/gobwas/glob@v0.2.3/glob.go:57
github.com/errata-ai/vale/v3/internal/glob.Glob.Match(...)
	internal/glob/glob.go:26
```

The panic happens inside a goroutine partway through the walk, so it aborts the run with a stack trace rather than reporting a bad flag value.

After:

```
$ vale --glob='[a-]*.md' .
expected close range character
```

Same exit code, no stack trace.

## Cause

`NewGlob` and `Match` use two different glob engines. Validation happens in `NewGlob` via `doublestar.PathMatch`, but the actual matching in `Match` compiles the pattern with `glob.MustCompile`. The two grammars disagree on character ranges, so a pattern can pass construction and then panic on first use.

`MustCompile` was also being called once per candidate file, since `Match` compiled on every call.

## The fix

Compile in `NewGlob` with `glob.Compile` and store the result on the struct. An invalid pattern is now an error at construction, where the caller can report it, and `Match` uses the already-compiled matcher.

`**` patterns keep going through `doublestar`, which is what handled them before. Those leave `compiled` nil, and `Match` branches on that rather than re-testing the pattern string.

Behaviour on valid patterns is unchanged. Same tree, before and after binaries, identical output for `*.md`, `**/*.md`, `!*.md`, `{*.md,*.txt}`, `docs/**` and `*`.

## Verification

`TestInvalidGlob` in `internal/glob/glob_test.go` covers `[a-]` and `[a-b-c]`, the range family where the two engines diverge.

A `glob-invalid` case in `testdata/e2e/config-flags.yaml`, next to the existing `glob-negated-dir` case, pins the CLI behaviour end to end. Its golden was filled with the repo's own `go test ./internal/e2e -update`, not by hand.

Reverting `glob.go` while keeping both fails them, and nothing else:

```
--- FAIL: TestInvalidGlob
    glob_test.go:44: [a-]: expected an error, got {Pattern:[a-] Negated:false}
    glob_test.go:44: [a-b-c]: expected an error, got {Pattern:[a-b-c] Negated:false}
--- FAIL: TestScenarios/config/flags/glob-invalid
```

`go test ./internal/glob/... ./internal/e2e/...` is green with the fix. `golangci-lint run ./internal/glob/...` reports 0 issues and `gofmt -l` is clean.

*Disclosure: written with AI assistance (Claude Code). I built both binaries from this tree, reproduced the panic and the fixed output with the commands above, checked the six real-world patterns for parity, and ran the revert check myself.*
