### PR TITLE
fix(substitution): a suggestion containing PIPE was corrupted

### DIFF
--- a/internal/check/substitution.go
+++ b/internal/check/substitution.go
@@ -481,15 +481,34 @@ func subMsg(s Substitution, index int, observed string) (string, error) {
 func getOptions(match string) []string {
 	options := []string{}
 
-	// We want to ignore any escaped pipes, so make a temporary substitution:
-	//
-	// TODO: Add support for `.Split` in `regexp2`.
-	temp := strings.ReplaceAll(match, `\|`, "PIPE")
-
-	for _, option := range strings.Split(temp, "|") {
-		if option != "" {
-			options = append(options, strings.ReplaceAll(option, "PIPE", `|`))
+	// Split on unescaped `|` only. We scan rather than substitute a placeholder
+	// string: any sentinel we could pick is also text a user may legitimately
+	// suggest, and rewriting it back would corrupt the suggestion -- a swap of
+	// `PIPELINE` used to come back as `|LINE`.
+	var current strings.Builder
+	for i := 0; i < len(match); i++ {
+		switch match[i] {
+		case '\\':
+			// An escaped `|` is a literal pipe; anything else escaped is kept
+			// as-is so the option reads the way it was written.
+			if i+1 < len(match) && match[i+1] == '|' {
+				current.WriteByte('|')
+				i++
+			} else {
+				current.WriteByte('\\')
+			}
+		case '|':
+			if current.Len() > 0 {
+				options = append(options, current.String())
+			}
+			current.Reset()
+		default:
+			current.WriteByte(match[i])
 		}
+	}
+
+	if current.Len() > 0 {
+		options = append(options, current.String())
 	}
 
 	return options

--- a/internal/check/substitution_test.go
+++ b/internal/check/substitution_test.go
@@ -335,6 +335,12 @@ func TestOptions(t *testing.T) {
 		"foo|":        {"foo"},
 		"|":           {},
 		`\|`:          {"|"},
+
+		// A suggestion is literal replacement text, so an option that happens
+		// to contain the letters `PIPE` has to survive the split intact.
+		"PIPELINE":         {"PIPELINE"},
+		"PIPELINE|conduit": {"PIPELINE", "conduit"},
+		`PIPE\|LINE`:       {"PIPE|LINE"},
 	}
 
 	for pattern, expected := range cases {


### PR DESCRIPTION
A `substitution` suggestion containing the letters `PIPE` comes out mangled.

`swap: {pipeline: PIPELINE}` on the text `The pipeline is here.`:

```
before:  "Message": "Use '|LINE' instead of 'pipeline'."
         "Params": [ "|LINE" ]

after:   "Message": "Use 'PIPELINE' instead of 'pipeline'."
         "Params": [ "PIPELINE" ]
```

So the `replace` action offers to insert `|LINE`, which is not what the rule author wrote.

## Cause

`getOptions` protected escaped pipes by round-tripping through a sentinel:

```go
temp := strings.ReplaceAll(match, `\|`, "PIPE")
for _, option := range strings.Split(temp, "|") {
    options = append(options, strings.ReplaceAll(option, "PIPE", `|`))
}
```

The sentinel is ordinary text a user can legitimately suggest, so the second `ReplaceAll` rewrites their own content. `PIPE`, `PIPELINE`, `PIPELINING` are all affected.

## The fix

Scan for unescaped `|` instead of substituting a placeholder. No sentinel means nothing to collide with. The existing `TODO` about `regexp2` lacking `.Split` is why the helper is hand-rolled either way, so this does not add a workaround, it replaces one that could corrupt data with one that cannot.

Escaping still works: a swap of `A\|B` still yields `A|B`, verified on the built binary.

## Verification

Three cases added to `TestOptions` in `internal/check/substitution_test.go`: `PIPELINE` alone, `PIPELINE|conduit` (sentinel text plus a real split), and `PIPE\|LINE` (sentinel text plus an escaped pipe).

Reverting only the split back to the sentinel version fails it:

```
--- FAIL: TestOptions
    substitution_test.go:354: Expected 'PIPELINE', got '|LINE'
```

`go build ./...`, `gofmt -l` and `go test ./...` are clean, including the `e2e` and `lint` packages.

*Disclosure: written with AI assistance (Claude Code). I built binaries before and after and produced the JSON output above by running them, checked that escaped pipes still resolve, and ran the mutation check myself.*
