### PR TITLE
chore: remove unused Tokens convenience wrappers

### DIFF
--- a/internal/core/file.go
+++ b/internal/core/file.go
@@ -200,14 +200,8 @@ func NewFile(src string, config *Config) (*File, error) {
 	return &file, nil
 }
 
-// Tokens returns the tagged tokens of text, tagging it only once per document
-// however many rules ask for it.
-func (f *File) Tokens(text string) []tag.Token {
-	toks, _ := f.TokensWith("", text)
-	return toks
-}
-
-// TokensWith is Tokens, read with the named tagger.
+// TokensWith returns the tagged tokens of text, read with the named tagger,
+// tagging it only once per document however many rules ask for it.
 //
 // Two models disagree about the same sentence -- that is why a rule names
 // one -- so each is cached separately.

--- a/internal/nlp/prose.go
+++ b/internal/nlp/prose.go
@@ -213,13 +213,8 @@ type TokenCache struct {
 	tagged map[string][]tag.Token
 }
 
-// Tokens returns the tagged tokens of text, tagging it only the first time.
-func (c *TokenCache) Tokens(text string, info *Info) []tag.Token {
-	toks, _ := c.TokensWith("", text, info)
-	return toks
-}
-
-// TokensWith is Tokens, read with the named tagger.
+// TokensWith returns the tagged tokens of text, read with the named tagger,
+// tagging it only the first time.
 func (c *TokenCache) TokensWith(model, text string, info *Info) ([]tag.Token, error) {
 	if c == nil {
 		return textToTokensWith(model, text, info)


### PR DESCRIPTION
## Problem

`File.Tokens` and `TokenCache.Tokens` are convenience wrappers around `TokensWith` (with an empty model name) that have no callers anywhere in the codebase. `TokensWith` itself is what every check type actually uses.

## Fix

Removed both. No behavior change.

## Testing

Full repo suite and `-race` are clean.

## Related

Found during review of #1162. Split out here as an independent cleanup per the smaller-PR preference from #938.
