### PR TITLE
fix: a sequence rule with a negated scope double-reports every match

### DIFF
--- a/internal/check/sequence.go
+++ b/internal/check/sequence.go
@@ -611,11 +611,15 @@ func sentenceScope(declared []string) []string {
 			scopes = append(scopes, s)
 			continue
 		}
-		// Negation applies to the part being excluded, so it stays in front:
-		// `~list` narrows to sentences outside a list, not to something
-		// outside `sentence.list`.
-		if neg, found := strings.CutPrefix(s, "~"); found {
-			scopes = append(scopes, "~"+neg)
+		// A bare negated term names only what to exclude and never mentions
+		// `sentence` itself, so asksForSentence (scope.go) skips every
+		// `sentence.*` fragment block for it and the rule matched the whole
+		// unsegmented block instead -- narrowing to `~list` alone was a
+		// no-op. AND-ing `sentence` in front keeps the exclusion and still
+		// narrows: `sentence&~list` is "sentences outside a list", which is
+		// what the rule actually needs.
+		if strings.HasPrefix(s, "~") {
+			scopes = append(scopes, "sentence&"+s)
 			continue
 		}
 		// `paragraph` names no block of its own. Splitting wraps every block

--- a/internal/check/sequence_test.go
+++ b/internal/check/sequence_test.go
@@ -71,7 +71,15 @@ func TestSentenceScope(t *testing.T) {
 		{"a block scope is narrowed", []string{"list"}, []string{"sentence & list"}},
 		{"already a sentence scope", []string{"sentence"}, []string{"sentence"}},
 		{"already narrowed", []string{"sentence.list"}, []string{"sentence.list"}},
-		{"negation stays in front", []string{"~list"}, []string{"~list"}},
+		// A bare negated term never mentions `sentence`, so asksForSentence
+		// (scope.go) skipped every `sentence.*` fragment block for it and the
+		// rule matched the whole unsegmented block instead: `~list` alone left
+		// `s` unchanged. `sentence&~list` still excludes list items, but only
+		// within sentence-fragment blocks.
+		{"negation is AND-ed with sentence",
+			[]string{"~list"}, []string{"sentence&~list"}},
+		{"a chained negation is AND-ed the same way",
+			[]string{"~list&text"}, []string{"sentence&~list&text"}},
 		{"a selector is a term, not a sub-scope",
 			[]string{"doc(h2 + p)"}, []string{"sentence & doc(h2 + p)"}},
 		{"several at once",
@@ -102,6 +110,65 @@ func TestSentenceScope(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The real, dispatched consequence of the negation bug above: a plain rule
+// with a bare negated scope matched the same real-world sentence through two
+// different blocks at once. `~list` narrowed to nothing, so Scope.Matches
+// treated the rule as if it had no scope at all and matched both
+// `paragraph.text.md` and its own whole-block copy `text.md` -- the same
+// underlying text, dispatched to Run twice, once for each block. One real
+// match produced two identical alerts.
+//
+// Dispatched the way the real linter dispatches a `sequence` check: through
+// the same block splitting (nlp.Info.Compute) and scope matching
+// (Scope.Matches) it uses, instead of handing text to Run directly. A block
+// built by hand and passed straight to Run bypasses that dispatch entirely,
+// so it cannot see this bug at all.
+func TestSequenceNegatedScopeDoesNotDoubleReport(t *testing.T) {
+	rule, err := NewSequence(testConfig(), baseCheck{
+		"extends":    "sequence",
+		"name":       "Test.WidgetArrivedNegatedScope",
+		"level":      "error",
+		"ignorecase": true,
+		"message":    "matched",
+		"scope":      []string{"~list"},
+		"tokens": []interface{}{
+			map[string]interface{}{"pattern": "widget"},
+			map[string]interface{}{"pattern": "arrived", "skip": 1},
+		},
+	}, "Test.WidgetArrivedNegatedScope")
+	if err != nil {
+		t.Fatalf("building rule: %v", err)
+	}
+
+	text := "I bought a widget that arrived promptly, said the courier."
+
+	f := &core.File{NLP: nlp.Info{Segmentation: true, Splitting: true}}
+	paragraph := nlp.NewLinedBlock("", text, "text.md", 1)
+
+	blocks, cerr := f.NLP.Compute(&paragraph, true)
+	if cerr != nil {
+		t.Fatalf("computing blocks: %v", cerr)
+	}
+
+	scope := NewScope(rule.Fields().Scope)
+
+	var alerts []core.Alert
+	for _, blk := range blocks {
+		if !scope.Matches(blk) {
+			continue
+		}
+		got, rerr := rule.Run(blk, f, testConfig())
+		if rerr != nil {
+			t.Fatalf("running rule: %v", rerr)
+		}
+		alerts = append(alerts, got...)
+	}
+
+	if len(alerts) != 1 {
+		t.Errorf("produced %d alerts for one real match, want exactly 1", len(alerts))
 	}
 }
 


### PR DESCRIPTION
## Problem

A `sequence` rule with a bare negated scope (`scope: ~list`) reaches `Run` twice for the same real match: once via the whole-block copy of the text, once more via its own `paragraph.*` wrapper.

`File.AddAlert`'s own line/span dedup absorbs this before it reaches a real `vale` run's printed output. A user running `vale` today sees the correct single alert.

The bug is still worth fixing directly. It wastes a full extra match-and-tag pass per matching document. `Scope.Matches` also has a real guarantee: a `sequence` rule declaring any scope should only ever receive single-sentence blocks. This bug silently breaks that guarantee for a negated scope. Other code that relies on it holding, a later optimization for `sequence.Run`, say, can't do so safely while this stays broken.

## Root cause

`sentenceScope`'s negation branch was a no-op: `~list` narrowed to `~list`, itself, via `strings.CutPrefix(s, "~")` re-adding the same prefix it had just stripped.

A negated term never mentions `sentence`, so `asksForSentence` (`scope.go`) then skips every `sentence.*` fragment block for such a rule. `Scope.Matches` falls back to matching both the whole-block copy and its own `paragraph.*` wrapper, since neither selector was ever narrowed to ask for a sentence fragment specifically.

## Fix

The negation branch now AND-s `sentence` in front of the term instead of leaving it untouched, so `~list` narrows to `sentence&~list`, meaning sentences outside a list, the same as every other declared scope already does.

## Testing

- `TestSentenceScope`: two updated/added rows pinning the corrected narrowing (`~list` and a chained `~list&text`).
- `TestSequenceNegatedScopeDoesNotDoubleReport`: dispatches through the real pipeline, `Info.Compute` and `Scope.Matches`, not a hand-built block. It collects `Run`'s own return value directly, which skips `AddAlert`'s dedup entirely, so the double-dispatch is actually observable here. Verified against the pre-fix behavior directly: 2 alerts for one real match before the fix, 1 after.

No `internal/e2e` case: confirmed empirically that a real `vale` run's output is identical before and after this fix (`AddAlert`'s dedup already absorbs the duplicate), so an end-to-end case here would pass either way and prove nothing.

Full repo suite and `-race` are clean, including `internal/e2e`.

## Related

Found during review of #1162. Split out here as an independent, single-concern fix, alongside #1167 and #1168 at the time, both since closed for unrelated reasons.

