### PR TITLE
fix: correct ColemanLiau readability message to match its own threshold

### DIFF
--- a/testdata/styles/Readability/ColemanLiau.yml
+++ b/testdata/styles/Readability/ColemanLiau.yml
@@ -1,5 +1,5 @@
 extends: metric
-message: "Try to keep the Coleman–Liau Index grade (%s) below 19."
+message: "Try to keep the Coleman–Liau Index grade (%s) below 9."
 link: https://en.wikipedia.org/wiki/Coleman%E2%80%93Liau_index
 
 formula: |


### PR DESCRIPTION
## Problem

`Readability.ColemanLiau`'s message and its actual `condition` disagree:

```yaml
message: "Try to keep the Coleman–Liau Index grade (%s) below 19."
condition: "> 9"
```

The rule reports once the computed grade passes 9, but tells the user to keep it below 19.

## Why the message, not the condition

Every other formula in this style has its message threshold exactly match its `condition`: FleschKincaid (8/`> 8`), FleschReadingEase (70/`< 70`), GunningFog (10/`> 10`), SMOG (10/`> 10`), LIX (35/`> 35`), AutomatedReadability (8/`> 8`). ColemanLiau is the only one where they diverge.

Coleman-Liau's grade output is on the same US-grade-level scale as FleschKincaid's and AutomatedReadability's, both of which already use 8 as their threshold, so 9 fits the pattern the rest of the style follows. It also matches published guidance directly: general-audience writing is commonly recommended to target a Coleman-Liau grade around 8-10, with sources specifically citing "8 or less" for public-facing content ([readable.com](https://readable.com/readability/coleman-liau-readability-index/), [readabilityformulas.com](https://readabilityformulas.com/the-coleman-liau-readability-formula/)). A threshold of 19 sits past graduate/academic-level prose on this same scale and would rarely fire on real writing.

Traced the file's history via the GitHub API (local shallow clones don't have it). It's been touched exactly twice since `a140d309` ("feat: add Readability style", 2021-11-14), which added it fresh with these exact values, and a pure rename in 2022 with no content change. That founding commit also corrected `FleschReadingEase`'s threshold from 50 to 70 in the same diff. That confirms a deliberate tuning pass rather than a rushed first draft, so a transposed digit (9 becoming 19) in the message string is the likelier explanation. Nothing exercises the message text in a way that would surface the mismatch, so no test or reviewer caught it for about four years.

## Fix

Correct the message to match the condition, not the other way around, since 9 is the value consistent with the rest of the style and with published guidance:

```yaml
message: "Try to keep the Coleman–Liau Index grade (%s) below 9."
```

## Related

Closes #1171. Found while researching a `check[...]` rollup formula for #1163, not otherwise related.
